### PR TITLE
Setup ci/cd using Github actions

### DIFF
--- a/.github/workflows/build-app.yaml
+++ b/.github/workflows/build-app.yaml
@@ -1,0 +1,15 @@
+name: build-app
+run-name: ${{ github.actor }} is building the app
+on: [push]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+      - run: npm install -g pnpm
+      - run: pnpm install
+      - run: pnpm -r test
+      - run: pnpm -r build

--- a/apps/cli/tsconfig.json
+++ b/apps/cli/tsconfig.json
@@ -7,6 +7,6 @@
   "include": ["src/**/*"],
   "exclude": ["node_modules", "dist"],
   "references": [
-    { "path": "../../packages/core" }
+    { "path": "../../packages/engine" }
   ]
 }


### PR DESCRIPTION
## Summary

This MR introduces a basic GitHub Actions CI workflow for the monorepo and aligns the CLI TypeScript project reference with the current package structure.

## Changes

- Added GitHub Actions workflow: [.github/workflows/build-app.yaml](cci:7://file:///Users/mohamedmohamed/Desktop/projects/repostem/.github/workflows/build-app.yaml:0:0-0:0)
  - Runs on `push`
  - Uses Node.js `22`
  - Installs dependencies with `pnpm`
  - Runs workspace tests: `pnpm -r test`
  - Runs workspace builds: `pnpm -r build`
- Updated CLI TS project reference:
  - [apps/cli/tsconfig.json](cci:7://file:///Users/mohamedmohamed/Desktop/projects/repostem/apps/cli/tsconfig.json:0:0-0:0)
  - Changed reference from `../../packages/core` to `../../packages/engine`

## Why

- Ensure every push is validated by automated CI checks.
- Catch regressions early by running tests before build.
- Fix project references to reflect the actual package name/location (`engine` instead of `core`).

## Scope

- CI/CD bootstrap for build + test validation.
- No runtime feature changes.
- No API/interface changes.

## Verification

- Local branch pushed successfully.
- Workflow file is present in [.github/workflows/build-app.yaml](cci:7://file:///Users/mohamedmohamed/Desktop/projects/repostem/.github/workflows/build-app.yaml:0:0-0:0).
- CLI TypeScript reference now points to `packages/engine`.

## Breaking Changes

- None.