### PR TITLE
Implement snapshot persistence configuration (repostem init + config …

### DIFF
--- a/.github/workflows/build-app.yaml
+++ b/.github/workflows/build-app.yaml
@@ -12,6 +12,6 @@ jobs:
       - run: npm install -g pnpm
       - run: sudo apt-get update && sudo apt-get install -y python3 make g++
       - run: pnpm install
-      - run: pnpm rebuild sqlite3 --build-from-source
+      - run: npm rebuild sqlite3 --build-from-source
       - run: pnpm -r test
       - run: pnpm -r build

--- a/.github/workflows/build-app.yaml
+++ b/.github/workflows/build-app.yaml
@@ -10,8 +10,6 @@ jobs:
         with:
           node-version: '22'
       - run: npm install -g pnpm
-      - run: sudo apt-get update && sudo apt-get install -y python3 make g++
       - run: pnpm install
-      - run: npm rebuild sqlite3 --build-from-source
       - run: pnpm -r test
       - run: pnpm -r build

--- a/.github/workflows/build-app.yaml
+++ b/.github/workflows/build-app.yaml
@@ -10,6 +10,8 @@ jobs:
         with:
           node-version: '22'
       - run: npm install -g pnpm
+      - run: sudo apt-get update && sudo apt-get install -y python3 make g++
       - run: pnpm install
+      - run: pnpm rebuild sqlite3 --build-from-source
       - run: pnpm -r test
       - run: pnpm -r build

--- a/README.md
+++ b/README.md
@@ -10,6 +10,9 @@ RepoStem is a CLI tool that analyzes repositories as dependency graphs, computes
 # Install
 npm install -g @repostem/cli
 
+# Initialize persistence (optional)
+repostem init
+
 # Analyze a repository
 repostem analyze /path/to/your/repo
 
@@ -34,6 +37,7 @@ RepoStem aims to evolve into an AI Project Brain — a persistent cognition laye
 - **AI-Powered Insights**: Get natural language explanations of architectural issues
 
 ### CLI Commands
+- `init` - Initialize persistence for snapshot storage (SQLite or PostgreSQL)
 - `analyze` - Full repository analysis with dependency graph
 - `risk` - Risk metrics and scoring for all files
 - `cycles` - Detect and report circular dependencies
@@ -79,6 +83,40 @@ repostem ask /path/to/your/repo "Is src/utils.js fragile?"
 # Configuration
 
 RepoStem can be configured using a `.repostem.json` or `repostem.config.json` file in your repository root.
+
+## Persistence Configuration
+
+Use `repostem init` to enable snapshot persistence:
+
+```bash
+# Interactive mode
+repostem init
+
+# With flags
+repostem init --storage sqlite --db-path .repostem.db
+repostem init --storage postgresql --db-path postgresql://user:pass@localhost/db
+```
+
+This creates a `.repostem.json` configuration file:
+
+```json
+{
+  "respectGitignore": true,
+  "ignore": [],
+  "storage_type": "sqlite",
+  "storage_path": ".repostem.db",
+  "repo_id": "uuid-v4"
+}
+```
+
+### Reconfiguration
+
+If you run `repostem init` again on an already initialized repository, you'll see options:
+- **Reconfigure storage backend** - Change storage type/path while preserving repo_id
+- **Reset persistence** - Delete all snapshots but keep repo record
+- **Cancel** - Exit without changes
+
+The `repo_id` is preserved across storage reconfigurations to maintain repository identity.
 
 ## Ignore Patterns
 

--- a/apps/cli/README.md
+++ b/apps/cli/README.md
@@ -82,6 +82,34 @@ repostem ask "Is src/api/client.js fragile?"
 
 ## 📋 Commands
 
+### `init`
+Initialize repository for snapshot persistence with SQLite or PostgreSQL.
+
+```bash
+repostem init [options]
+```
+
+**Options:**
+- `-r, --repo <path>`: Path to repository (default: current directory)
+- `-s, --storage <type>`: Storage type - `sqlite` or `postgresql` (default: prompt)
+- `-p, --db-path <path>`: Database path for SQLite or connection string for PostgreSQL
+
+**Reconfiguration:**
+If you run `repostem init` on an already initialized repository, you'll see options:
+- **Reconfigure storage backend** - Change storage type/path while preserving repo_id
+- **Reset persistence** - Delete all snapshots but keep repo record
+- **Cancel** - Exit without changes
+
+**Example:**
+```bash
+# Interactive mode
+repostem init
+
+# With flags
+repostem init --storage sqlite --db-path .repostem.db
+repostem init --storage postgresql --db-path postgresql://user:pass@localhost/db
+```
+
 ### `analyze`
 Run full structural analysis on the repository and print project-level structural summary.
 

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -18,6 +18,7 @@
     "chalk": "^5.6.2",
     "commander": "^14.0.3",
     "dotenv": "^17.4.1",
+    "inquirer": "^12.6.0",
     "lodash": "^4.18.0"
   },
   "license": "MIT",

--- a/apps/cli/src/commands/init.ts
+++ b/apps/cli/src/commands/init.ts
@@ -1,0 +1,279 @@
+import { Command } from "commander";
+import inquirer from "inquirer";
+import { 
+  initializeRepo, 
+  isRepoInitialized, 
+  checkConfigFile, 
+  StorageType, 
+  resetPersistence, 
+  getConfig,
+  AdapterFactory,
+  RepoRepository
+} from "@repostem/engine";
+import path from "path";
+import { InitOptions } from "../types";
+
+const STORAGE_TYPE_SQLITE = "sqlite";
+const STORAGE_TYPE_POSTGRESQL = "postgresql";
+const DEFAULT_SQLITE_PATH = ".repostem.db";
+
+/**
+ * Check if repository is already initialized and show menu
+ */
+async function handleExistingConfig(repoPath: string): Promise<string | null> {
+  const configExists = checkConfigFile(repoPath);
+  const alreadyInitialized = isRepoInitialized(repoPath);
+
+  if (configExists && alreadyInitialized) {
+    const config = getConfig(repoPath);
+    
+    // Validate that repo_id exists in database
+    if (config.repo_id && config.storage_type && config.storage_path) {
+      const repoIdExists = await validateRepoIdExists(config.repo_id, config.storage_type, config.storage_path);
+      
+      if (!repoIdExists) {
+        console.log("Warning: Config file exists but repo_id not found in database.");
+        console.log("This may indicate a corrupted or incomplete initialization.");
+        const { reinit } = await inquirer.prompt([
+          {
+            type: "confirm",
+            name: "reinit",
+            message: "Would you like to reinitialize the repository?",
+            default: true,
+          },
+        ]);
+        
+        if (reinit) {
+          return "reconfigure";
+        } else {
+          return "cancel";
+        }
+      }
+    }
+    
+    console.log("This project is already initialized.");
+    
+    const { action } = await inquirer.prompt([
+      {
+        type: "list",
+        name: "action",
+        message: "Options:",
+        choices: [
+          { name: "Reconfigure storage backend", value: "reconfigure" },
+          { name: "Reset persistence (delete existing snapshots)", value: "reset" },
+          { name: "Cancel", value: "cancel" },
+        ],
+      },
+    ]);
+
+    return action;
+  }
+
+  return null;
+}
+
+/**
+ * Validate that a repo_id exists in the database
+ */
+async function validateRepoIdExists(repoId: string, storageType: StorageType, storagePath: string): Promise<boolean> {
+  try {
+    const adapter = AdapterFactory.createAdapterFromString(storageType, storagePath);
+    await adapter.connect();
+    
+    const repoRepository = new RepoRepository(adapter);
+    const repo = await repoRepository.getRepoById(repoId);
+    
+    await adapter.disconnect();
+    
+    return repo !== undefined;
+  } catch (error) {
+    return false;
+  }
+}
+
+/**
+ * Collect storage type from flag or prompt
+ */
+async function collectStorageType(storageFlag?: string): Promise<StorageType> {
+  if (storageFlag) {
+    const normalized = storageFlag.toLowerCase();
+    if (normalized !== STORAGE_TYPE_SQLITE && normalized !== STORAGE_TYPE_POSTGRESQL) {
+      console.error(`Invalid storage type: ${storageFlag}. Must be '${STORAGE_TYPE_SQLITE}' or '${STORAGE_TYPE_POSTGRESQL}'.`);
+      process.exit(1);
+    }
+    return normalized as StorageType;
+  }
+
+  const { selectedStorage } = await inquirer.prompt([
+    {
+      type: "list",
+      name: "selectedStorage",
+      message: "Select storage type:",
+      choices: [
+        { name: "SQLite (local file)", value: STORAGE_TYPE_SQLITE },
+        { name: "PostgreSQL (remote database)", value: STORAGE_TYPE_POSTGRESQL },
+      ],
+      default: STORAGE_TYPE_SQLITE,
+    },
+  ]);
+
+  return selectedStorage as StorageType;
+}
+
+/**
+ * Collect storage path from flag or prompt based on storage type
+ */
+async function collectStoragePath(
+  repoPath: string,
+  storageType: StorageType,
+  dbPathFlag?: string
+): Promise<string> {
+  if (dbPathFlag) {
+    return dbPathFlag;
+  }
+
+  if (storageType === STORAGE_TYPE_SQLITE) {
+    const defaultPath = path.join(repoPath, DEFAULT_SQLITE_PATH);
+    const { dbPathInput } = await inquirer.prompt([
+      {
+        type: "input",
+        name: "dbPathInput",
+        message: "Enter SQLite database path:",
+        default: defaultPath,
+        validate: (input: string) => {
+          if (!input.trim()) {
+            return "Path cannot be empty";
+          }
+          return true;
+        },
+      },
+    ]);
+    return dbPathInput;
+  } else {
+    const { connectionString } = await inquirer.prompt([
+      {
+        type: "input",
+        name: "connectionString",
+        message: "Enter PostgreSQL connection string (e.g., postgresql://user:password@localhost:5432/dbname):",
+        validate: (input: string) => {
+          if (!input.trim()) {
+            return "Connection string cannot be empty";
+          }
+          if (!input.startsWith("postgresql://") && !input.startsWith("postgres://")) {
+            return "Connection string must start with postgresql:// or postgres://";
+          }
+          return true;
+        },
+      },
+    ]);
+    return connectionString;
+  }
+}
+
+/**
+ * Normalize storage path to absolute for SQLite
+ */
+function normalizeStoragePath(repoPath: string, storageType: StorageType, storagePath: string): string {
+  if (storageType === STORAGE_TYPE_SQLITE && !path.isAbsolute(storagePath)) {
+    return path.resolve(repoPath, storagePath);
+  }
+  return storagePath;
+}
+
+/**
+ * Initialize repository and display results
+ */
+async function performInitialization(
+  repoPath: string,
+  storageType: StorageType,
+  storagePath: string,
+  repoId?: string
+): Promise<void> {
+  console.log(`\nInitializing repository...`);
+  console.log(`  Repository: ${repoPath}`);
+  console.log(`  Storage: ${storageType}`);
+  console.log(`  Path: ${storagePath}\n`);
+
+  const result = await initializeRepo(repoPath, {
+    storageType,
+    storagePath,
+    repoId,
+  });
+
+  if (result.success) {
+    console.log("Success! Repository initialized for persistence.");
+    console.log(`\n${result.message}`);
+    console.log(`\nConfiguration saved to: ${path.join(repoPath, ".repostem.json")}`);
+  } else {
+    console.error("Initialization failed:", result.message);
+    process.exit(1);
+  }
+}
+
+export default new Command()
+  .name("init")
+  .description("Initialize repository for snapshot persistence with SQLite or PostgreSQL")
+  .option("-r, --repo <path>", "Path to repository")
+  .option("-s, --storage <type>", "Storage type (sqlite or postgresql)")
+  .option("-p, --db-path <path>", "Database path (for SQLite) or connection string (for PostgreSQL)")
+  .action(async (options: InitOptions) => {
+    const repoPath = options.repo || process.cwd();
+
+    try {
+      const action = await handleExistingConfig(repoPath);
+
+      if (action === "cancel") {
+        console.log("Operation cancelled.");
+        return;
+      }
+
+      if (action === "reset") {
+        const { confirmReset } = await inquirer.prompt([
+          {
+            type: "confirm",
+            name: "confirmReset",
+            message: "This will delete all existing snapshots. Are you sure?",
+            default: false,
+          },
+        ]);
+
+        if (!confirmReset) {
+          console.log("Reset cancelled.");
+          return;
+        }
+
+        try {
+          const result = await resetPersistence(repoPath);
+          console.log(result.message);
+        } catch (error) {
+          const message = error instanceof Error ? error.message : String(error);
+          console.error(`Error resetting persistence: ${message}`);
+          process.exit(1);
+        }
+        return;
+      }
+
+      // For both new init and reconfigure
+      const storageType = await collectStorageType(options.storage);
+      let storagePath = await collectStoragePath(repoPath, storageType, options.dbPath);
+      storagePath = normalizeStoragePath(repoPath, storageType, storagePath);
+
+      // Get existing repo_id if reconfiguring
+      let repoId: string | undefined;
+      if (action === "reconfigure") {
+        const config = getConfig(repoPath);
+        repoId = config.repo_id;
+      }
+
+      await performInitialization(
+        repoPath,
+        storageType,
+        storagePath,
+        repoId
+      );
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      console.error(`Error: ${message}`);
+      process.exit(1);
+    }
+  });

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -6,6 +6,7 @@ import riskCommand from "./commands/risk";
 import askCommand from "./commands/ask";
 import cyclesCommand from "./commands/cycles";
 import impactCommand from "./commands/impact";
+import initCommand from "./commands/init";
 import { readFileSync } from "fs";
 import { join } from "path";
 
@@ -20,6 +21,7 @@ program
   .description(packageJson.description)
   .version(packageJson.version);
 
+program.addCommand(initCommand);
 program.addCommand(analyzeCommand);
 program.addCommand(riskCommand);
 program.addCommand(impactCommand);

--- a/apps/cli/src/types.ts
+++ b/apps/cli/src/types.ts
@@ -1,0 +1,5 @@
+export interface InitOptions {
+  repo?: string;
+  storage?: string;
+  dbPath?: string;
+}

--- a/docs/architecture-v2.md
+++ b/docs/architecture-v2.md
@@ -173,17 +173,21 @@ the comparison logic will be as follows:
 
 ## repostem init
 - check if a config file `.repostem.json` exists in the current directory
-- if the file exists, warn the user the project is already initialized and the config will be overwritten
-- if not, ask the user if they want to persist snapshots in the SQL database,
-- if yes, make the user to select the storage type (SQLite orPostgreSQL)
-- if SQLite, create a SQL database file `.repostem.db` in the current directory
+- if the file exists and the repo is already initialized, present the user with options:
+  1. Reconfigure storage backend (change storage type/path while preserving repo_id)
+  2. Reset persistence (delete all snapshots but keep repo record)
+  3. Cancel
+- if the file does not exist, ask the user to select the storage type (SQLite or PostgreSQL)
+- if SQLite, create a SQL database file `.repostem.db` in the current directory (or custom path)
 - if PostgreSQL, ask the user to provide the connection string
-- save the config file `.repostem.json` in the current directory if it doesn't exist otherwise update it
+- save the config file `.repostem.json` in the current directory
 - the config file will contain the following fields:
   - storage_type (SQLite or PostgreSQL)
   - storage_path (path to the SQL database file for SQLite or connection string for PostgreSQL)
+  - repo_id (unique identifier for the repository)
 - initialize the database schema
-- generate a repo_id using `uuid.uuid4()` and save it in the table `repo` along with the root path
+- generate a repo_id using UUID and save it in the table `repo` along with the root path
+- when reconfiguring storage, the existing repo_id is preserved to maintain identity across storage changes
 
 ## repostem analyze
 - check if a config file `.repostem.json` exists in the current directory
@@ -390,3 +394,5 @@ in this version, this command will cover more qeustions allowing the users to as
 - AI never computes structural metrics; it only explains deterministic results.
 - Snapshots represent structural state at time T, not Git commit state (Snapshots may represent uncommitted working tree states.
 Commit metadata is informational only.)
+- Persistence is optional and configured via `repostem init`.
+- Running `repostem init` again does not regenerate `repo_id` unless explicitly reset

--- a/packages/engine/README.md
+++ b/packages/engine/README.md
@@ -127,6 +127,53 @@ Classifies repository structure and patterns.
 const classification = await classify('/path/to/repo');
 ```
 
+### `initializeRepo(repositoryRoot: string, options: InitRepoOptions)`
+
+Initialize repository for snapshot persistence with SQLite or PostgreSQL.
+
+```typescript
+const result = await initializeRepo('/path/to/repo', {
+  storageType: 'sqlite',
+  storagePath: '.repostem.db',
+  repoId: 'optional-existing-repo-id' // for reconfiguration
+});
+
+// Returns:
+{
+  success: boolean;
+  repoId: string;
+  config: RepoStemConfig;
+  migrationResult: MigrationResult;
+  message: string;
+}
+```
+
+**Note**: When reconfiguring storage, provide the existing `repoId` to preserve repository identity.
+
+### `isRepoInitialized(repositoryRoot: string)`
+
+Check if a repository is initialized for persistence.
+
+```typescript
+const initialized = isRepoInitialized('/path/to/repo');
+// Returns: boolean
+```
+
+### `resetPersistence(repositoryRoot: string)`
+
+Reset persistence by deleting all snapshots for a repository while keeping the repo record.
+
+```typescript
+const result = await resetPersistence('/path/to/repo');
+
+// Returns:
+{
+  success: boolean;
+  message: string;
+  snapshotsDeleted: number;
+}
+```
+
 ## Metrics Explained
 
 ### Centrality

--- a/packages/engine/package.json
+++ b/packages/engine/package.json
@@ -5,23 +5,28 @@
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "scripts": {
-    "build": "tsc",
+    "build": "tsc && npm run copy-schema",
+    "copy-schema": "cp -r src/persistence/schema/*.sql dist/persistence/schema/ 2>/dev/null || mkdir -p dist/persistence/schema && cp -r src/persistence/schema/*.sql dist/persistence/schema/",
     "dev": "tsc --watch",
     "test": "vitest run --config vitest.config.ts",
     "test:watch": "vitest --config vitest.config.ts"
   },
   "dependencies": {
     "@types/lodash": "^4.17.24",
+    "knex": "^3.1.0",
     "lodash": "^4.18.0",
     "minimatch": "^10.2.5",
     "openai": "^4.77.3",
+    "pg": "^8.14.1",
     "simple-git": "^3.35.2",
+    "sqlite3": "^5.1.7",
     "tree-sitter": "^0.21.1",
     "tree-sitter-javascript": "^0.23.0",
     "tree-sitter-typescript": "^0.23.2",
     "ts-node": "^10.9.2"
   },
   "devDependencies": {
+    "@types/knex": "^0.0.38",
     "vitest": "^4.1.2"
   },
   "license": "MIT",

--- a/packages/engine/src/config/config-loader.ts
+++ b/packages/engine/src/config/config-loader.ts
@@ -1,33 +1,157 @@
-import { existsSync, readFileSync } from 'fs';
+import { existsSync, readFileSync, writeFileSync, mkdirSync } from 'fs';
 import path from 'path';
 import { DEFAULT_IGNORE_PATTERNS } from './default-ignore-patterns';
 import { RepoStemConfig } from '../types';
 
-export function loadConfig(repositoryRoot: string): RepoStemConfig {
-  const configPaths = [
-    path.join(repositoryRoot, '.repostem.json'),
-    path.join(repositoryRoot, 'repostem.config.json')
-  ];
+const CONFIG_FILE_NAME = '.repostem.json';
+const ALTERNATIVE_CONFIG_FILE_NAME = 'repostem.config.json';
 
-  for (const configPath of configPaths) {
-    if (existsSync(configPath)) {
-      try {
-        const configContent = readFileSync(configPath, 'utf-8');
-        const config = JSON.parse(configContent) as RepoStemConfig;
-        return {
-          respectGitignore: config.respectGitignore ?? true,
-          ignore: config.ignore || []
-        };
-      } catch (error) {
-        console.warn(`Failed to parse config file at ${configPath}:`, error);
-      }
+/**
+ * Get the path to the config file
+ * Checks for .repostem.json first, then repostem.config.json as fallback
+ */
+function getConfigPath(repositoryRoot: string): string {
+  const primaryPath = path.join(repositoryRoot, CONFIG_FILE_NAME);
+  const alternativePath = path.join(repositoryRoot, ALTERNATIVE_CONFIG_FILE_NAME);
+  
+  if (existsSync(primaryPath)) {
+    return primaryPath;
+  }
+  
+  if (existsSync(alternativePath)) {
+    return alternativePath;
+  }
+  
+  return primaryPath;
+}
+
+/**
+ * Check if a config file exists
+ * @param repositoryRoot - The root path of the repository
+ * @returns True if config file exists
+ */
+export function checkConfigFile(repositoryRoot: string): boolean {
+  const primaryPath = path.join(repositoryRoot, CONFIG_FILE_NAME);
+  const alternativePath = path.join(repositoryRoot, ALTERNATIVE_CONFIG_FILE_NAME);
+  return existsSync(primaryPath) || existsSync(alternativePath);
+}
+
+/**
+ * Load the config file (alias for getConfig for backward compatibility)
+ * @param repositoryRoot - The root path of the repository
+ * @returns The config object
+ */
+export function loadConfig(repositoryRoot: string): RepoStemConfig {
+  return getConfig(repositoryRoot);
+}
+
+/**
+ * Get the full config object
+ * @param repositoryRoot - The root path of the repository
+ * @returns The config object
+ */
+export function getConfig(repositoryRoot: string): RepoStemConfig {
+  const configPath = getConfigPath(repositoryRoot);
+
+  if (existsSync(configPath)) {
+    try {
+      const configContent = readFileSync(configPath, 'utf-8');
+      const config = JSON.parse(configContent) as RepoStemConfig;
+      return {
+        respectGitignore: config.respectGitignore ?? true,
+        ignore: config.ignore || [],
+        storage_type: config.storage_type,
+        storage_path: config.storage_path,
+        repo_id: config.repo_id,
+      };
+    } catch (error) {
+      console.warn(`Failed to parse config file at ${configPath}:`, error);
     }
   }
 
   return {
     respectGitignore: true,
-    ignore: []
+    ignore: [],
   };
+}
+
+/**
+ * Create a new config file
+ * @param repositoryRoot - The root path of the repository
+ * @param config - The config to write
+ * @returns The path to the created config file
+ */
+export function createConfigFile(
+  repositoryRoot: string,
+  config: Partial<RepoStemConfig>
+): string {
+  const configPath = getConfigPath(repositoryRoot);
+  
+  // Ensure directory exists
+  const dir = path.dirname(configPath);
+  if (!existsSync(dir)) {
+    mkdirSync(dir, { recursive: true });
+  }
+
+  const fullConfig: RepoStemConfig = {
+    respectGitignore: config.respectGitignore ?? true,
+    ignore: config.ignore || [],
+    storage_type: config.storage_type,
+    storage_path: config.storage_path,
+    repo_id: config.repo_id,
+  };
+
+  writeFileSync(configPath, JSON.stringify(fullConfig, null, 2), 'utf-8');
+  return configPath;
+}
+
+/**
+ * Update an existing config file (merge with existing)
+ * @param repositoryRoot - The root path of the repository
+ * @param updates - The config updates to merge
+ * @returns The path to the updated config file
+ */
+export function updateConfigFile(
+  repositoryRoot: string,
+  updates: Partial<RepoStemConfig>
+): string {
+  const existingConfig = getConfig(repositoryRoot);
+  const mergedConfig: RepoStemConfig = {
+    ...existingConfig,
+    ...updates,
+  };
+
+  // Preserve ignore patterns if not explicitly overwritten
+  if (!updates.ignore && existingConfig.ignore) {
+    mergedConfig.ignore = existingConfig.ignore;
+  }
+
+  return createConfigFile(repositoryRoot, mergedConfig);
+}
+
+/**
+ * Add or update a single config key
+ * @param repositoryRoot - The root path of the repository
+ * @param key - The config key to update
+ * @param value - The value to set
+ * @returns The path to the updated config file
+ */
+export function addConfig(
+  repositoryRoot: string,
+  key: keyof RepoStemConfig,
+  value: any
+): string {
+  return updateConfigFile(repositoryRoot, { [key]: value });
+}
+
+/**
+ * Check if persistence is configured
+ * @param repositoryRoot - The root path of the repository
+ * @returns True if storage_type, storage_path, and repo_id are set
+ */
+export function isPersistenceConfigured(repositoryRoot: string): boolean {
+  const config = getConfig(repositoryRoot);
+  return !!(config.storage_type && config.storage_path && config.repo_id);
 }
 
 export function getAllIgnorePatterns(repositoryRoot: string): string[] {

--- a/packages/engine/src/engine.test.ts
+++ b/packages/engine/src/engine.test.ts
@@ -28,6 +28,66 @@ vi.mock('./ai-explanation-layer/intent-router', () => ({
     })
 }));
 
+// Mock database adapters
+vi.mock('./persistence/adapters', () => ({
+    AdapterFactory: {
+        createAdapterFromString: vi.fn(() => ({
+            connect: vi.fn().mockResolvedValue(undefined),
+            disconnect: vi.fn().mockResolvedValue(undefined),
+            query: vi.fn().mockResolvedValue([]),
+        }))
+    },
+    DatabaseType: {
+        SQLITE: 'sqlite',
+        POSTGRESQL: 'postgresql'
+    }
+}));
+
+// Mock repositories
+vi.mock('./persistence/repositories', () => ({
+    RepoRepository: class {
+        constructor(adapter: any) {}
+        async createRepo(repoId: string, rootPath: string) {}
+        async getRepoById(repoId: string) { return undefined; }
+    },
+    SnapshotRepository: class {
+        constructor(adapter: any) {}
+        async createSnapshot(snapshot: any) {}
+        async getSnapshotsByRepoId(repoId: string) { return []; }
+        async deleteSnapshot(snapshotId: string) {}
+    }
+}));
+
+// Mock migrations
+vi.mock('./persistence/migrations', () => ({
+    runInitMigration: vi.fn().mockResolvedValue({
+        success: true,
+        message: 'Migration successful',
+        tablesCreated: ['repo', 'snapshot', 'file_snapshot', 'dependency_edge', 'cycle']
+    }),
+    isSchemaInitialized: vi.fn().mockResolvedValue(false)
+}));
+
+// Mock config functions
+const mockConfig = {
+    respectGitignore: true,
+    ignore: [],
+    storage_type: undefined as string | undefined,
+    storage_path: undefined as string | undefined,
+    repo_id: undefined as string | undefined
+};
+
+vi.mock('./config/config-loader', () => ({
+    getConfig: vi.fn(() => ({ ...mockConfig })),
+    updateConfigFile: vi.fn((repoPath: string, config: any) => {
+        Object.assign(mockConfig, config);
+        return '/path/to/.repostem.json';
+    }),
+    isPersistenceConfigured: vi.fn(() => !!mockConfig.storage_type && !!mockConfig.storage_path && !!mockConfig.repo_id),
+    checkConfigFile: vi.fn(() => false),
+    getAllIgnorePatterns: vi.fn(() => ['node_modules/**', '.git/**', 'dist/**'])
+}));
+
 const sharedFixturesRoot = path.resolve(__dirname, "__tests__", "fixtures", "shared");
 const basicRepoPath = path.join(sharedFixturesRoot, "basic-repo");
 
@@ -634,6 +694,13 @@ describe('Engine - Integration Tests', () => {
 });
 
 describe('Engine - Persistence Functions', () => {
+    beforeEach(() => {
+        // Reset mock config state before each test
+        mockConfig.storage_type = undefined;
+        mockConfig.storage_path = undefined;
+        mockConfig.repo_id = undefined;
+    });
+
     describe('initializeRepo', () => {
         it('should initialize repository with new repo_id', async () => {
             const testRepoPath = '/tmp/test-repostem-init-repo';
@@ -651,6 +718,7 @@ describe('Engine - Persistence Functions', () => {
             expect(result.config.storage_type).toBe('sqlite');
             expect(result.config.storage_path).toBe('/tmp/test-repostem-init.db');
             expect(result.migrationResult).toBeDefined();
+            expect(result.migrationResult.success).toBe(true);
         });
 
         it('should use existing repo_id when provided (reconfiguration)', async () => {

--- a/packages/engine/src/engine.test.ts
+++ b/packages/engine/src/engine.test.ts
@@ -6,7 +6,10 @@ import {
     computeFileImpact,
     detectRepositoryCycles,
     ask,
-    explainFileRisk
+    explainFileRisk,
+    initializeRepo,
+    isRepoInitialized,
+    resetPersistence
 } from './engine';
 import { ProjectAnalysisResult, FileRiskResult, FileImpactResult, Cycle } from './types';
 
@@ -626,6 +629,87 @@ describe('Engine - Integration Tests', () => {
             const validResults = results.filter(r => r !== null);
             
             expect(validResults.length).toBeGreaterThan(0);
+        });
+    });
+});
+
+describe('Engine - Persistence Functions', () => {
+    describe('initializeRepo', () => {
+        it('should initialize repository with new repo_id', async () => {
+            const testRepoPath = '/tmp/test-repostem-init-repo';
+            const result = await initializeRepo(testRepoPath, {
+                storageType: 'sqlite',
+                storagePath: '/tmp/test-repostem-init.db'
+            });
+
+            expect(result).toBeDefined();
+            expect(result.success).toBe(true);
+            expect(result.repoId).toBeDefined();
+            expect(typeof result.repoId).toBe('string');
+            expect(result.config).toBeDefined();
+            expect(result.config.repo_id).toBe(result.repoId);
+            expect(result.config.storage_type).toBe('sqlite');
+            expect(result.config.storage_path).toBe('/tmp/test-repostem-init.db');
+            expect(result.migrationResult).toBeDefined();
+        });
+
+        it('should use existing repo_id when provided (reconfiguration)', async () => {
+            const testRepoPath = '/tmp/test-repostem-reconfigure';
+            const existingRepoId = 'test-repo-id-12345';
+            
+            const result = await initializeRepo(testRepoPath, {
+                storageType: 'sqlite',
+                storagePath: '/tmp/test-repostem-reconfigure.db',
+                repoId: existingRepoId
+            });
+
+            expect(result).toBeDefined();
+            expect(result.success).toBe(true);
+            expect(result.repoId).toBe(existingRepoId);
+            expect(result.config.repo_id).toBe(existingRepoId);
+        });
+    });
+
+    describe('isRepoInitialized', () => {
+        it('should return false when repo is not initialized', () => {
+            const testRepoPath = '/tmp/test-repostem-not-initialized';
+            const result = isRepoInitialized(testRepoPath);
+            expect(result).toBe(false);
+        });
+
+        it('should return true when repo is initialized', () => {
+            const testRepoPath = '/tmp/test-repostem-initialized';
+            const result = isRepoInitialized(testRepoPath);
+            expect(typeof result).toBe('boolean');
+        });
+    });
+
+    describe('resetPersistence', () => {
+        it('should reset persistence and delete snapshots', async () => {
+            const testRepoPath = '/tmp/test-repostem-reset';
+            
+            // First initialize the repo
+            await initializeRepo(testRepoPath, {
+                storageType: 'sqlite',
+                storagePath: '/tmp/test-repostem-reset.db'
+            });
+            
+            // Then reset it
+            const result = await resetPersistence(testRepoPath);
+
+            expect(result).toBeDefined();
+            expect(result.success).toBe(true);
+            expect(result.message).toBeDefined();
+            expect(typeof result.snapshotsDeleted).toBe('number');
+            expect(result.snapshotsDeleted).toBeGreaterThanOrEqual(0);
+        });
+
+        it('should throw error when repo is not properly initialized', async () => {
+            const testRepoPath = '/tmp/test-repostem-not-init';
+            
+            await expect(
+                resetPersistence(testRepoPath)
+            ).rejects.toThrow();
         });
     });
 });

--- a/packages/engine/src/engine.ts
+++ b/packages/engine/src/engine.ts
@@ -2,16 +2,14 @@ import parseRepository from "./core/parser/parser";
 import { buildDependencyGraph } from "./core/dependency-graph/dependency-graph";
 import { computeFileMetrics, computeMetrics } from "./core/metrics-engine/metrics-engine";
 import { computeRisk } from "./core/risk-engine/risk-engine";
-import { Cycle, FileAnalysis, FileImpactResult, FileRiskResult, ProjectAnalysisResult, RankedFile } from "./types";
+import { Cycle, FileAnalysis, FileImpactResult, FileRiskResult, ProjectAnalysisResult, RankedFile, RepoStemConfig, ResetPersistenceResult, StorageType } from "./types";
 import { classify } from "./utils/classify";
 import { detectIntent, explainImpactIntent, explainRiskIntent } from "./ai-explanation-layer/intent-router";
-
-interface MetricConfig {
-    key: string;
-    extractValue: (fileAnalysis: FileAnalysis, metrics: any) => number;
-    threshold?: number;
-    sortDescending?: boolean;
-}
+import { AdapterFactory } from "./persistence/adapters";
+import { runInitMigration, MigrationResult } from "./persistence/migrations";
+import { RepoRepository, SnapshotRepository } from "./persistence/repositories";
+import { getConfig, updateConfigFile, isPersistenceConfigured } from "./config/config-loader";
+import { MetricConfig } from "./types";
 
 const intentMap: Record<string, (repoPath: string, filePath: string, explain?: boolean) => Promise<string>> = {
     "risk": explainFileRisk,
@@ -176,4 +174,165 @@ export async function ask(question: string, repoPath: string): Promise<string> {
     return intentMap[intent](repoPath, filePath, true);
 }
 
-export { classify, explainFileRisk, explainFileImpact };
+///////////////////////////////////////////////////////////////////////////////
+// Repository Initialization
+
+/**
+ * Options for initializing a repository
+ */
+export interface InitRepoOptions {
+  storageType: StorageType;
+  storagePath: string;
+  repoId?: string;
+}
+
+/**
+ * Result of initializing a repository
+ */
+export interface InitRepoResult {
+  success: boolean;
+  repoId: string;
+  config: RepoStemConfig;
+  migrationResult: MigrationResult;
+  message: string;
+}
+
+/**
+ * Initialize a repository for persistence
+ * 
+ * @param repositoryRoot - The root path of the repository
+ * @param options - Initialization options (storageType, storagePath)
+ * @returns InitRepoResult with repoId and config
+ */
+async function initializeRepo(
+  repositoryRoot: string,
+  options: InitRepoOptions
+): Promise<InitRepoResult> {
+  const { storageType, storagePath, repoId: existingRepoId } = options;
+
+  // Create database adapter
+  const adapter = AdapterFactory.createAdapterFromString(storageType, storagePath);
+
+  try {
+    // Connect to database
+    await adapter.connect();
+
+    // Run migrations
+    const migrationResult = await runInitMigration(adapter);
+
+    if (!migrationResult.success) {
+      throw new Error(`Migration failed: ${migrationResult.message}`);
+    }
+
+    const repoRepository = new RepoRepository(adapter);
+    let repoId: string;
+
+    if (existingRepoId) {
+      // Use existing repo_id (for reconfiguration)
+      repoId = existingRepoId;
+      
+      // Check if repo record exists in new database
+      const existingRepo = await repoRepository.getRepoById(repoId);
+      
+      if (!existingRepo) {
+        // Insert repo record if missing
+        await repoRepository.createRepo(repoId, repositoryRoot);
+      }
+    } else {
+      // Generate new repo UUID (for new initialization)
+      repoId = crypto.randomUUID();
+      await repoRepository.createRepo(repoId, repositoryRoot);
+    }
+
+    // Update config file with repo_id
+    updateConfigFile(repositoryRoot, {
+      storage_type: storageType,
+      storage_path: storagePath,
+      repo_id: repoId,
+    });
+
+    // Get the updated config
+    const updatedConfig = getConfig(repositoryRoot);
+
+    // Disconnect from database
+    await adapter.disconnect();
+
+    return {
+      success: true,
+      repoId,
+      config: updatedConfig,
+      migrationResult,
+      message: `Repository initialized successfully.\n` +
+        `Repo ID: ${repoId}\n` +
+        `Storage: ${storageType} at ${storagePath}\n` +
+        `Tables created: ${migrationResult.tablesCreated.length}`,
+    };
+  } catch (error) {
+    // Ensure disconnect on error
+    try {
+      await adapter.disconnect();
+    } catch {
+      // Ignore disconnect errors
+    }
+
+    throw error;
+  }
+}
+
+/**
+ * Check if a repository is initialized for persistence
+ * 
+ * @param repositoryRoot - The root path of the repository
+ * @returns True if persistence is configured
+ */
+function isRepoInitialized(repositoryRoot: string): boolean {
+  return isPersistenceConfigured(repositoryRoot);
+}
+
+/**
+ * Reset persistence by deleting all snapshots for a repository
+ * This keeps the repo record but deletes all associated snapshots and their data
+ * 
+ * @param repositoryRoot - The root path of the repository
+ * @returns ResetPersistenceResult indicating success and number of snapshots deleted
+ */
+export async function resetPersistence(repositoryRoot: string): Promise<ResetPersistenceResult> {
+  const config = getConfig(repositoryRoot);
+
+  if (!config.storage_type || !config.storage_path || !config.repo_id) {
+    throw new Error("Repository is not properly initialized for persistence.");
+  }
+
+  const adapter = AdapterFactory.createAdapterFromString(config.storage_type, config.storage_path);
+
+  try {
+    await adapter.connect();
+
+    const snapshotRepository = new SnapshotRepository(adapter);
+    const snapshots = await snapshotRepository.getSnapshotsByRepoId(config.repo_id);
+
+    const snapshotCount = snapshots.length;
+
+    // Delete all snapshots (cascade will delete related data)
+    for (const snapshot of snapshots) {
+      await snapshotRepository.deleteSnapshot(snapshot.id);
+    }
+
+    await adapter.disconnect();
+
+    return {
+      success: true,
+      message: `Successfully reset persistence. Deleted ${snapshotCount} snapshot(s).`,
+      snapshotsDeleted: snapshotCount,
+    };
+  } catch (error) {
+    try {
+      await adapter.disconnect();
+    } catch {
+      // Ignore disconnect errors
+    }
+    throw error;
+  }
+}
+
+export { classify, explainFileRisk, explainFileImpact, initializeRepo, isRepoInitialized };

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -9,8 +9,7 @@ export {
     isRepoInitialized,
     resetPersistence,
     InitRepoOptions,
-    InitRepoResult,
-    ResetPersistenceResult
+    InitRepoResult
 } from './engine';
 
 export { getMetricLabel, METRIC_LABELS } from './metric-labels';

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -4,9 +4,37 @@ export {
     computeFileImpact,
     detectRepositoryCycles,
     ask,
-    classify
+    classify,
+    initializeRepo,
+    isRepoInitialized,
+    resetPersistence,
+    InitRepoOptions,
+    InitRepoResult,
+    ResetPersistenceResult
 } from './engine';
 
 export { getMetricLabel, METRIC_LABELS } from './metric-labels';
 
 export * from './types';
+
+// Config exports
+export {
+    checkConfigFile,
+    getConfig,
+    createConfigFile,
+    updateConfigFile,
+    addConfig,
+    isPersistenceConfigured
+} from './config/config-loader';
+
+// Persistence exports
+export {
+  AdapterFactory,
+  DatabaseType,
+  DatabaseAdapter
+} from './persistence/adapters';
+
+export {
+  RepoRepository,
+  RepoRecord
+} from './persistence/repositories';

--- a/packages/engine/src/persistence/adapters/adapter-factory.ts
+++ b/packages/engine/src/persistence/adapters/adapter-factory.ts
@@ -1,0 +1,53 @@
+import { DatabaseAdapter } from './database-adapter.interface';
+import { SQLiteAdapter } from './sqlite-adapter';
+import { PostgreSQLAdapter } from './postgresql-adapter';
+
+/**
+ * Enum for supported database types
+ */
+export enum DatabaseType {
+  SQLite = 'sqlite',
+  PostgreSQL = 'postgresql',
+}
+
+/**
+ * Factory for creating database adapters
+ */
+export class AdapterFactory {
+  /**
+   * Create a database adapter based on the database type
+   * @param type - The type of database (SQLite or PostgreSQL)
+   * @param connectionString - Connection string or file path
+   * @returns DatabaseAdapter instance
+   */
+  static createAdapter(type: DatabaseType, connectionString: string): DatabaseAdapter {
+    switch (type) {
+      case DatabaseType.SQLite:
+        return new SQLiteAdapter(connectionString);
+      case DatabaseType.PostgreSQL:
+        return new PostgreSQLAdapter(connectionString);
+      default:
+        throw new Error(`Unsupported database type: ${type}`);
+    }
+  }
+
+  /**
+   * Create a database adapter from a string type
+   * @param type - The type as a string ('sqlite' or 'postgresql')
+   * @param connectionString - Connection string or file path
+   * @returns DatabaseAdapter instance
+   */
+  static createAdapterFromString(type: string, connectionString: string): DatabaseAdapter {
+    const normalizedType = type.toLowerCase();
+    
+    if (normalizedType === 'sqlite') {
+      return this.createAdapter(DatabaseType.SQLite, connectionString);
+    }
+    
+    if (normalizedType === 'postgresql' || normalizedType === 'postgres') {
+      return this.createAdapter(DatabaseType.PostgreSQL, connectionString);
+    }
+    
+    throw new Error(`Unsupported database type: ${type}. Supported types: sqlite, postgresql`);
+  }
+}

--- a/packages/engine/src/persistence/adapters/database-adapter.interface.ts
+++ b/packages/engine/src/persistence/adapters/database-adapter.interface.ts
@@ -1,0 +1,47 @@
+import { Knex } from 'knex';
+
+/**
+ * Database adapter interface for supporting multiple database backends
+ */
+export interface DatabaseAdapter {
+  /**
+   * Get the Knex instance for direct database operations
+   */
+  getKnex(): Knex;
+
+  /**
+   * Connect to the database
+   */
+  connect(): Promise<void>;
+
+  /**
+   * Disconnect from the database
+   */
+  disconnect(): Promise<void>;
+
+  /**
+   * Run a raw SQL migration
+   * @param sql - The SQL to execute
+   */
+  runMigration(sql: string): Promise<void>;
+
+  /**
+   * Execute a raw SQL query
+   * @param sql - The SQL query
+   * @param params - Optional parameters for prepared statements
+   */
+  query<T = any>(sql: string, params?: any[]): Promise<T[]>;
+
+  /**
+   * Execute a raw SQL statement (for INSERT, UPDATE, DELETE)
+   * @param sql - The SQL statement
+   * @param params - Optional parameters for prepared statements
+   */
+  execute(sql: string, params?: any[]): Promise<void>;
+
+  /**
+   * Check if a table exists
+   * @param tableName - The name of the table to check
+   */
+  tableExists(tableName: string): Promise<boolean>;
+}

--- a/packages/engine/src/persistence/adapters/index.ts
+++ b/packages/engine/src/persistence/adapters/index.ts
@@ -1,0 +1,4 @@
+export { DatabaseAdapter } from './database-adapter.interface';
+export { SQLiteAdapter } from './sqlite-adapter';
+export { PostgreSQLAdapter } from './postgresql-adapter';
+export { AdapterFactory, DatabaseType } from './adapter-factory';

--- a/packages/engine/src/persistence/adapters/postgresql-adapter.ts
+++ b/packages/engine/src/persistence/adapters/postgresql-adapter.ts
@@ -1,0 +1,70 @@
+import { Knex } from 'knex';
+import { DatabaseAdapter } from './database-adapter.interface';
+import knex from 'knex';
+
+/**
+ * PostgreSQL database adapter implementation
+ */
+export class PostgreSQLAdapter implements DatabaseAdapter {
+  private knex: Knex;
+  private connectionString: string;
+
+  constructor(connectionString: string) {
+    this.connectionString = connectionString;
+    this.knex = knex({
+      client: 'pg',
+      connection: connectionString,
+    });
+  }
+
+  getKnex(): Knex {
+    return this.knex;
+  }
+
+  async connect(): Promise<void> {
+    // Test the connection by running a simple query
+    await this.knex.raw('SELECT 1');
+  }
+
+  async disconnect(): Promise<void> {
+    await this.knex.destroy();
+  }
+
+  async runMigration(sql: string): Promise<void> {
+    // PostgreSQL can execute multiple statements in one raw call
+    // Filter out SQLite-specific PRAGMA statements
+    const statements = sql
+      .split(';')
+      .map(s => s.trim())
+      .filter(s => s.length > 0 && !s.toUpperCase().startsWith('PRAGMA'));
+
+    for (const statement of statements) {
+      await this.knex.raw(statement);
+    }
+  }
+
+  async query<T = any>(sql: string, params?: any[]): Promise<T[]> {
+    if (params) {
+      const result = await this.knex.raw(sql, params);
+      return result.rows;
+    }
+    const result = await this.knex.raw(sql);
+    return result.rows;
+  }
+
+  async execute(sql: string, params?: any[]): Promise<void> {
+    if (params) {
+      await this.knex.raw(sql, params);
+    } else {
+      await this.knex.raw(sql);
+    }
+  }
+
+  async tableExists(tableName: string): Promise<boolean> {
+    const result = await this.knex.raw(
+      "SELECT to_regclass(?) as name",
+      [tableName]
+    );
+    return result.rows.length > 0 && result.rows[0].name !== null;
+  }
+}

--- a/packages/engine/src/persistence/adapters/sqlite-adapter.ts
+++ b/packages/engine/src/persistence/adapters/sqlite-adapter.ts
@@ -1,0 +1,73 @@
+import { Knex } from 'knex';
+import { DatabaseAdapter } from './database-adapter.interface';
+import knex from 'knex';
+
+/**
+ * SQLite database adapter implementation
+ */
+export class SQLiteAdapter implements DatabaseAdapter {
+  private knex: Knex;
+  private dbPath: string;
+
+  constructor(dbPath: string) {
+    this.dbPath = dbPath;
+    this.knex = knex({
+      client: 'sqlite3',
+      connection: {
+        filename: dbPath,
+      },
+      useNullAsDefault: true,
+    });
+  }
+
+  getKnex(): Knex {
+    return this.knex;
+  }
+
+  async connect(): Promise<void> {
+    // Test the connection by running a simple query
+    await this.knex.raw('SELECT 1');
+  }
+
+  async disconnect(): Promise<void> {
+    await this.knex.destroy();
+  }
+
+  async runMigration(sql: string): Promise<void> {
+    // SQLite can execute multiple statements in one raw call
+    // Split by semicolon and execute each statement
+    const statements = sql
+      .split(';')
+      .map(s => s.trim())
+      .filter(s => s.length > 0);
+
+    for (const statement of statements) {
+      await this.knex.raw(statement);
+    }
+  }
+
+  async query<T = any>(sql: string, params?: any[]): Promise<T[]> {
+    if (params) {
+      const result = await this.knex.raw(sql, params);
+      return result as T[];
+    }
+    const result = await this.knex.raw(sql);
+    return result as T[];
+  }
+
+  async execute(sql: string, params?: any[]): Promise<void> {
+    if (params) {
+      await this.knex.raw(sql, params);
+    } else {
+      await this.knex.raw(sql);
+    }
+  }
+
+  async tableExists(tableName: string): Promise<boolean> {
+    const result = await this.knex.raw(
+      "SELECT name FROM sqlite_master WHERE type='table' AND name=?",
+      [tableName]
+    );
+    return result.length > 0;
+  }
+}

--- a/packages/engine/src/persistence/index.ts
+++ b/packages/engine/src/persistence/index.ts
@@ -1,0 +1,27 @@
+// Adapters
+export { DatabaseAdapter } from './adapters';
+export { SQLiteAdapter } from './adapters';
+export { PostgreSQLAdapter } from './adapters';
+export { AdapterFactory, DatabaseType } from './adapters';
+
+// Migrations
+export { runInitMigration, isSchemaInitialized, MigrationResult } from './migrations';
+
+// Repositories
+export {
+  RepoRepository,
+  RepoRecord,
+  SnapshotRepository,
+  SnapshotRecord,
+  CreateSnapshotData,
+  FileSnapshotRepository,
+  FileSnapshotRecord,
+  CreateFileSnapshotData,
+  EdgeRepository,
+  EdgeRecord,
+  CreateEdgeData,
+  CycleRepository,
+  CycleRecord,
+  CreateCycleData,
+  ParsedCycle,
+} from './repositories';

--- a/packages/engine/src/persistence/migrations.ts
+++ b/packages/engine/src/persistence/migrations.ts
@@ -1,0 +1,110 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import { DatabaseAdapter } from './adapters';
+
+/**
+ * Result of running a migration
+ */
+export interface MigrationResult {
+  success: boolean;
+  message: string;
+  tablesCreated: string[];
+}
+
+/**
+ * Tables that should be created by the init migration
+ */
+const EXPECTED_TABLES = [
+  'repo',
+  'snapshot',
+  'file_snapshot',
+  'dependency_edge',
+  'cycle',
+];
+
+/**
+ * Run the init schema migration
+ * This is idempotent - it checks if tables exist before creating
+ * 
+ * @param adapter - The database adapter to use
+ * @param sqlFilePath - Optional path to the SQL file (defaults to schema/001_init_schema.sql)
+ * @returns MigrationResult indicating success/failure and tables created
+ */
+export async function runInitMigration(
+  adapter: DatabaseAdapter,
+  sqlFilePath?: string
+): Promise<MigrationResult> {
+  try {
+    // Check which tables already exist
+    const existingTables: string[] = [];
+    const tablesToCreate: string[] = [];
+
+    for (const table of EXPECTED_TABLES) {
+      const exists = await adapter.tableExists(table);
+      if (exists) {
+        existingTables.push(table);
+      } else {
+        tablesToCreate.push(table);
+      }
+    }
+
+    // If all tables exist, migration is already complete
+    if (existingTables.length === EXPECTED_TABLES.length) {
+      return {
+        success: true,
+        message: 'All tables already exist. Migration skipped.',
+        tablesCreated: [],
+      };
+    }
+
+    // Read the SQL file
+    const migrationPath = sqlFilePath || path.join(__dirname, 'schema', '001_init_schema.sql');
+    
+    if (!fs.existsSync(migrationPath)) {
+      throw new Error(`Migration file not found: ${migrationPath}`);
+    }
+
+    const sql = fs.readFileSync(migrationPath, 'utf-8');
+
+    // Run the migration
+    await adapter.runMigration(sql);
+
+    // Verify tables were created
+    const createdTables: string[] = [];
+    for (const table of tablesToCreate) {
+      const exists = await adapter.tableExists(table);
+      if (exists) {
+        createdTables.push(table);
+      }
+    }
+
+    return {
+      success: true,
+      message: `Migration completed successfully. Created ${createdTables.length} new tables.`,
+      tablesCreated: createdTables,
+    };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Unknown error during migration';
+    return {
+      success: false,
+      message: `Migration failed: ${message}`,
+      tablesCreated: [],
+    };
+  }
+}
+
+/**
+ * Check if the database schema is initialized
+ * 
+ * @param adapter - The database adapter to use
+ * @returns boolean indicating if all required tables exist
+ */
+export async function isSchemaInitialized(adapter: DatabaseAdapter): Promise<boolean> {
+  for (const table of EXPECTED_TABLES) {
+    const exists = await adapter.tableExists(table);
+    if (!exists) {
+      return false;
+    }
+  }
+  return true;
+}

--- a/packages/engine/src/persistence/repositories/cycle-repository.ts
+++ b/packages/engine/src/persistence/repositories/cycle-repository.ts
@@ -1,0 +1,159 @@
+import { Knex } from 'knex';
+import { DatabaseAdapter } from '../adapters';
+
+/**
+ * Cycle record type
+ */
+export interface CycleRecord {
+  id: string;
+  snapshot_id: string;
+  nodes: string; // JSON stringified array of file paths
+}
+
+/**
+ * Data for creating a cycle
+ */
+export interface CreateCycleData {
+  id: string;
+  snapshotId: string;
+  nodes: string[];
+}
+
+/**
+ * Parsed cycle with nodes as array
+ */
+export interface ParsedCycle {
+  id: string;
+  snapshotId: string;
+  nodes: string[];
+}
+
+/**
+ * Repository for cycle table operations
+ */
+export class CycleRepository {
+  private knex: Knex;
+  private static TABLE_NAME = 'cycle';
+
+  constructor(adapter: DatabaseAdapter) {
+    this.knex = adapter.getKnex();
+  }
+
+  /**
+   * Insert a single cycle record
+   * @param data - The cycle data
+   * @returns The created record
+   */
+  async insertCycle(data: CreateCycleData): Promise<CycleRecord> {
+    const record: CycleRecord = {
+      id: data.id,
+      snapshot_id: data.snapshotId,
+      nodes: JSON.stringify(data.nodes),
+    };
+
+    await this.knex(CycleRepository.TABLE_NAME).insert(record);
+
+    return record;
+  }
+
+  /**
+   * Batch insert cycle records
+   * @param snapshotId - The snapshot ID
+   * @param cycles - Array of node arrays (each array represents one cycle)
+   * @param idGenerator - Function to generate IDs (default: crypto.randomUUID)
+   */
+  async batchInsertCycles(
+    snapshotId: string,
+    cycles: string[][],
+    idGenerator: () => string = () => crypto.randomUUID()
+  ): Promise<void> {
+    if (cycles.length === 0) return;
+
+    const records = cycles.map(nodes => ({
+      id: idGenerator(),
+      snapshot_id: snapshotId,
+      nodes: JSON.stringify(nodes),
+    }));
+
+    await this.knex(CycleRepository.TABLE_NAME).insert(records);
+  }
+
+  /**
+   * Get all cycles for a snapshot
+   * @param snapshotId - The snapshot ID
+   * @returns Array of parsed cycle records
+   */
+  async getCycles(snapshotId: string): Promise<ParsedCycle[]> {
+    const rows = await this.knex(CycleRepository.TABLE_NAME)
+      .where({ snapshot_id: snapshotId })
+      .select('*');
+    
+    return rows.map(row => ({
+      id: row.id,
+      snapshotId: row.snapshot_id,
+      nodes: JSON.parse(row.nodes),
+    }));
+  }
+
+  /**
+   * Get a specific cycle by ID
+   * @param id - The cycle ID
+   * @returns The parsed cycle record or undefined
+   */
+  async getCycleById(id: string): Promise<ParsedCycle | undefined> {
+    const rows = await this.knex(CycleRepository.TABLE_NAME)
+      .where({ id })
+      .select('*');
+    
+    if (!rows[0]) return undefined;
+
+    return {
+      id: rows[0].id,
+      snapshotId: rows[0].snapshot_id,
+      nodes: JSON.parse(rows[0].nodes),
+    };
+  }
+
+  /**
+   * Count cycles for a snapshot
+   * @param snapshotId - The snapshot ID
+   * @returns The count of cycles
+   */
+  async countCycles(snapshotId: string): Promise<number> {
+    const result = await this.knex(CycleRepository.TABLE_NAME)
+      .where({ snapshot_id: snapshotId })
+      .count('* as count')
+      .first();
+    
+    return Number(result?.count || 0);
+  }
+
+  /**
+   * Find cycles that contain a specific file
+   * @param snapshotId - The snapshot ID
+   * @param filePath - The file path to search for
+   * @returns Array of parsed cycles containing the file
+   */
+  async getCyclesContainingFile(snapshotId: string, filePath: string): Promise<ParsedCycle[]> {
+    const cycles = await this.getCycles(snapshotId);
+    return cycles.filter(cycle => cycle.nodes.includes(filePath));
+  }
+
+  /**
+   * Delete all cycles for a snapshot
+   * @param snapshotId - The snapshot ID
+   */
+  async deleteCycles(snapshotId: string): Promise<void> {
+    await this.knex(CycleRepository.TABLE_NAME)
+      .where({ snapshot_id: snapshotId })
+      .delete();
+  }
+
+  /**
+   * Delete a specific cycle by ID
+   * @param id - The cycle ID
+   */
+  async deleteCycleById(id: string): Promise<void> {
+    await this.knex(CycleRepository.TABLE_NAME).where({ id }).delete();
+  }
+}

--- a/packages/engine/src/persistence/repositories/edge-repository.ts
+++ b/packages/engine/src/persistence/repositories/edge-repository.ts
@@ -1,0 +1,150 @@
+import { Knex } from 'knex';
+import { DatabaseAdapter } from '../adapters';
+
+/**
+ * Dependency edge record type
+ */
+export interface EdgeRecord {
+  snapshot_id: string;
+  from_file: string;
+  to_file: string;
+}
+
+/**
+ * Data for creating an edge
+ */
+export interface CreateEdgeData {
+  snapshotId: string;
+  fromFile: string;
+  toFile: string;
+}
+
+/**
+ * Repository for dependency_edge table operations
+ */
+export class EdgeRepository {
+  private knex: Knex;
+  private static TABLE_NAME = 'dependency_edge';
+
+  constructor(adapter: DatabaseAdapter) {
+    this.knex = adapter.getKnex();
+  }
+
+  /**
+   * Insert a single edge record
+   * @param data - The edge data
+   * @returns The created record
+   */
+  async insertEdge(data: CreateEdgeData): Promise<EdgeRecord> {
+    const record: EdgeRecord = {
+      snapshot_id: data.snapshotId,
+      from_file: data.fromFile,
+      to_file: data.toFile,
+    };
+
+    await this.knex(EdgeRepository.TABLE_NAME).insert(record);
+
+    return record;
+  }
+
+  /**
+   * Batch insert edge records
+   * @param snapshotId - The snapshot ID
+   * @param edges - Array of edge data (fromFile, toFile pairs)
+   */
+  async batchInsertEdges(
+    snapshotId: string,
+    edges: { fromFile: string; toFile: string }[]
+  ): Promise<void> {
+    if (edges.length === 0) return;
+
+    const records = edges.map(edge => ({
+      snapshot_id: snapshotId,
+      from_file: edge.fromFile,
+      to_file: edge.toFile,
+    }));
+
+    await this.knex(EdgeRepository.TABLE_NAME).insert(records);
+  }
+
+  /**
+   * Get all edges for a snapshot
+   * @param snapshotId - The snapshot ID
+   * @returns Array of edge records
+   */
+  async getEdges(snapshotId: string): Promise<EdgeRecord[]> {
+    const rows = await this.knex(EdgeRepository.TABLE_NAME)
+      .where({ snapshot_id: snapshotId })
+      .select('*');
+    
+    return rows as EdgeRecord[];
+  }
+
+  /**
+   * Get outgoing edges from a file
+   * @param snapshotId - The snapshot ID
+   * @param fromFile - The source file path
+   * @returns Array of edge records
+   */
+  async getOutgoingEdges(snapshotId: string, fromFile: string): Promise<EdgeRecord[]> {
+    const rows = await this.knex(EdgeRepository.TABLE_NAME)
+      .where({ snapshot_id: snapshotId, from_file: fromFile })
+      .select('*');
+    
+    return rows as EdgeRecord[];
+  }
+
+  /**
+   * Get incoming edges to a file
+   * @param snapshotId - The snapshot ID
+   * @param toFile - The target file path
+   * @returns Array of edge records
+   */
+  async getIncomingEdges(snapshotId: string, toFile: string): Promise<EdgeRecord[]> {
+    const rows = await this.knex(EdgeRepository.TABLE_NAME)
+      .where({ snapshot_id: snapshotId, to_file: toFile })
+      .select('*');
+    
+    return rows as EdgeRecord[];
+  }
+
+  /**
+   * Count edges for a snapshot
+   * @param snapshotId - The snapshot ID
+   * @returns The count of edges
+   */
+  async countEdges(snapshotId: string): Promise<number> {
+    const result = await this.knex(EdgeRepository.TABLE_NAME)
+      .where({ snapshot_id: snapshotId })
+      .count('* as count')
+      .first();
+    
+    return Number(result?.count || 0);
+  }
+
+  /**
+   * Check if an edge exists
+   * @param snapshotId - The snapshot ID
+   * @param fromFile - The source file path
+   * @param toFile - The target file path
+   * @returns True if edge exists
+   */
+  async edgeExists(snapshotId: string, fromFile: string, toFile: string): Promise<boolean> {
+    const count = await this.knex(EdgeRepository.TABLE_NAME)
+      .where({ snapshot_id: snapshotId, from_file: fromFile, to_file: toFile })
+      .count('* as count')
+      .first();
+    
+    return Number(count?.count || 0) > 0;
+  }
+
+  /**
+   * Delete all edges for a snapshot
+   * @param snapshotId - The snapshot ID
+   */
+  async deleteEdges(snapshotId: string): Promise<void> {
+    await this.knex(EdgeRepository.TABLE_NAME)
+      .where({ snapshot_id: snapshotId })
+      .delete();
+  }
+}

--- a/packages/engine/src/persistence/repositories/file-snapshot-repository.ts
+++ b/packages/engine/src/persistence/repositories/file-snapshot-repository.ts
@@ -1,0 +1,162 @@
+import { Knex } from 'knex';
+import { DatabaseAdapter } from '../adapters';
+
+/**
+ * File snapshot record type
+ */
+export interface FileSnapshotRecord {
+  snapshot_id: string;
+  file_path: string;
+  dependency_importance: number | null;
+  connectivity: number | null;
+  churn: number | null;
+  risk_score: number | null;
+  risk_level: 'HIGH' | 'MEDIUM' | 'LOW' | null;
+  impact_count: number;
+}
+
+/**
+ * Data for creating a file snapshot
+ */
+export interface CreateFileSnapshotData {
+  snapshotId: string;
+  filePath: string;
+  dependencyImportance?: number | null;
+  connectivity?: number | null;
+  churn?: number | null;
+  riskScore?: number | null;
+  riskLevel?: 'HIGH' | 'MEDIUM' | 'LOW' | null;
+  impactCount?: number;
+}
+
+/**
+ * Repository for file_snapshot table operations
+ */
+export class FileSnapshotRepository {
+  private knex: Knex;
+  private static TABLE_NAME = 'file_snapshot';
+
+  constructor(adapter: DatabaseAdapter) {
+    this.knex = adapter.getKnex();
+  }
+
+  /**
+   * Insert a single file snapshot record
+   * @param data - The file snapshot data
+   * @returns The created record
+   */
+  async insertFileSnapshot(data: CreateFileSnapshotData): Promise<FileSnapshotRecord> {
+    const record: FileSnapshotRecord = {
+      snapshot_id: data.snapshotId,
+      file_path: data.filePath,
+      dependency_importance: data.dependencyImportance || null,
+      connectivity: data.connectivity || null,
+      churn: data.churn || null,
+      risk_score: data.riskScore || null,
+      risk_level: data.riskLevel || null,
+      impact_count: data.impactCount || 0,
+    };
+
+    await this.knex(FileSnapshotRepository.TABLE_NAME).insert(record);
+
+    return record;
+  }
+
+  /**
+   * Batch insert file snapshot records
+   * @param snapshotId - The snapshot ID
+   * @param fileData - Array of file snapshot data
+   */
+  async batchInsertFileSnapshots(
+    snapshotId: string,
+    fileData: Omit<CreateFileSnapshotData, 'snapshotId'>[]
+  ): Promise<void> {
+    if (fileData.length === 0) return;
+
+    const records = fileData.map(data => ({
+      snapshot_id: snapshotId,
+      file_path: data.filePath,
+      dependency_importance: data.dependencyImportance || null,
+      connectivity: data.connectivity || null,
+      churn: data.churn || null,
+      risk_score: data.riskScore || null,
+      risk_level: data.riskLevel || null,
+      impact_count: data.impactCount || 0,
+    }));
+
+    await this.knex(FileSnapshotRepository.TABLE_NAME).insert(records);
+  }
+
+  /**
+   * Get all file snapshots for a snapshot
+   * @param snapshotId - The snapshot ID
+   * @returns Array of file snapshot records
+   */
+  async getFileSnapshots(snapshotId: string): Promise<FileSnapshotRecord[]> {
+    const rows = await this.knex(FileSnapshotRepository.TABLE_NAME)
+      .where({ snapshot_id: snapshotId })
+      .select('*');
+    
+    return rows as FileSnapshotRecord[];
+  }
+
+  /**
+   * Get a specific file snapshot
+   * @param snapshotId - The snapshot ID
+   * @param filePath - The file path
+   * @returns The file snapshot record or undefined
+   */
+  async getFileSnapshot(
+    snapshotId: string,
+    filePath: string
+  ): Promise<FileSnapshotRecord | undefined> {
+    const rows = await this.knex(FileSnapshotRepository.TABLE_NAME)
+      .where({ snapshot_id: snapshotId, file_path: filePath })
+      .select('*');
+    
+    return rows[0] as FileSnapshotRecord | undefined;
+  }
+
+  /**
+   * Get high risk files for a snapshot
+   * @param snapshotId - The snapshot ID
+   * @param threshold - Risk score threshold (default 0.6)
+   * @returns Array of high risk file snapshot records
+   */
+  async getHighRiskFiles(
+    snapshotId: string,
+    threshold: number = 0.6
+  ): Promise<FileSnapshotRecord[]> {
+    const rows = await this.knex(FileSnapshotRepository.TABLE_NAME)
+      .where({ snapshot_id: snapshotId })
+      .where('risk_score', '>=', threshold)
+      .orderBy('risk_score', 'desc')
+      .select('*');
+    
+    return rows as FileSnapshotRecord[];
+  }
+
+  /**
+   * Count file snapshots for a snapshot
+   * @param snapshotId - The snapshot ID
+   * @returns The count of file snapshots
+   */
+  async countFileSnapshots(snapshotId: string): Promise<number> {
+    const result = await this.knex(FileSnapshotRepository.TABLE_NAME)
+      .where({ snapshot_id: snapshotId })
+      .count('* as count')
+      .first();
+    
+    return Number(result?.count || 0);
+  }
+
+  /**
+   * Delete all file snapshots for a snapshot
+   * @param snapshotId - The snapshot ID
+   */
+  async deleteFileSnapshots(snapshotId: string): Promise<void> {
+    await this.knex(FileSnapshotRepository.TABLE_NAME)
+      .where({ snapshot_id: snapshotId })
+      .delete();
+  }
+}

--- a/packages/engine/src/persistence/repositories/index.ts
+++ b/packages/engine/src/persistence/repositories/index.ts
@@ -1,0 +1,5 @@
+export { RepoRepository, RepoRecord } from './repo-repository';
+export { SnapshotRepository, SnapshotRecord, CreateSnapshotData } from './snapshot-repository';
+export { FileSnapshotRepository, FileSnapshotRecord, CreateFileSnapshotData } from './file-snapshot-repository';
+export { EdgeRepository, EdgeRecord, CreateEdgeData } from './edge-repository';
+export { CycleRepository, CycleRecord, CreateCycleData, ParsedCycle } from './cycle-repository';

--- a/packages/engine/src/persistence/repositories/repo-repository.ts
+++ b/packages/engine/src/persistence/repositories/repo-repository.ts
@@ -1,0 +1,93 @@
+import { Knex } from 'knex';
+import { DatabaseAdapter } from '../adapters';
+
+/**
+ * Repository record type
+ */
+export interface RepoRecord {
+  id: string;
+  root_path: string;
+  created_at: Date;
+}
+
+/**
+ * Repository for repo table operations
+ */
+export class RepoRepository {
+  private knex: Knex;
+  private static TABLE_NAME = 'repo';
+
+  constructor(adapter: DatabaseAdapter) {
+    this.knex = adapter.getKnex();
+  }
+
+  /**
+   * Create a new repo record
+   * @param id - The UUID for the repo
+   * @param rootPath - The root path of the repository
+   * @returns The created repo record
+   */
+  async createRepo(id: string, rootPath: string): Promise<RepoRecord> {
+    const record: RepoRecord = {
+      id,
+      root_path: rootPath,
+      created_at: new Date(),
+    };
+
+    await this.knex(RepoRepository.TABLE_NAME).insert({
+      id: record.id,
+      root_path: record.root_path,
+      created_at: record.created_at,
+    });
+
+    return record;
+  }
+
+  /**
+   * Get a repo by ID
+   * @param id - The repo ID
+   * @returns The repo record or undefined if not found
+   */
+  async getRepoById(id: string): Promise<RepoRecord | undefined> {
+    const rows = await this.knex(RepoRepository.TABLE_NAME)
+      .where({ id })
+      .select('*');
+    
+    return rows[0] as RepoRecord | undefined;
+  }
+
+  /**
+   * Get a repo by root path
+   * @param rootPath - The root path of the repository
+   * @returns The repo record or undefined if not found
+   */
+  async getRepoByRootPath(rootPath: string): Promise<RepoRecord | undefined> {
+    const rows = await this.knex(RepoRepository.TABLE_NAME)
+      .where({ root_path: rootPath })
+      .select('*');
+    
+    return rows[0] as RepoRecord | undefined;
+  }
+
+  /**
+   * Check if a repo exists by root path
+   * @param rootPath - The root path of the repository
+   * @returns True if repo exists
+   */
+  async repoExists(rootPath: string): Promise<boolean> {
+    const count = await this.knex(RepoRepository.TABLE_NAME)
+      .where({ root_path: rootPath })
+      .count('* as count')
+      .first();
+    
+    return Number(count?.count || 0) > 0;
+  }
+
+  /**
+   * Delete a repo by ID (cascades to all related tables)
+   * @param id - The repo ID
+   */
+  async deleteRepo(id: string): Promise<void> {
+    await this.knex(RepoRepository.TABLE_NAME).where({ id }).delete();
+  }
+}

--- a/packages/engine/src/persistence/repositories/snapshot-repository.ts
+++ b/packages/engine/src/persistence/repositories/snapshot-repository.ts
@@ -1,0 +1,170 @@
+import { Knex } from 'knex';
+import { DatabaseAdapter } from '../adapters';
+
+/**
+ * Snapshot record type
+ */
+export interface SnapshotRecord {
+  id: string;
+  repo_id: string;
+  git_remote_url: string | null;
+  branch: string | null;
+  commit_hash: string | null;
+  working_tree_dirty: boolean;
+  total_files: number | null;
+  cycle_count: number | null;
+  created_at: Date;
+}
+
+/**
+ * Data for creating a new snapshot
+ */
+export interface CreateSnapshotData {
+  id: string;
+  repoId: string;
+  gitRemoteUrl?: string | null;
+  branch?: string | null;
+  commitHash?: string | null;
+  workingTreeDirty?: boolean;
+  totalFiles?: number | null;
+  cycleCount?: number | null;
+}
+
+/**
+ * Repository for snapshot table operations
+ */
+export class SnapshotRepository {
+  private knex: Knex;
+  private static TABLE_NAME = 'snapshot';
+
+  constructor(adapter: DatabaseAdapter) {
+    this.knex = adapter.getKnex();
+  }
+
+  /**
+   * Create a new snapshot record
+   * @param data - The snapshot data
+   * @returns The created snapshot record
+   */
+  async createSnapshot(data: CreateSnapshotData): Promise<SnapshotRecord> {
+    const record: SnapshotRecord = {
+      id: data.id,
+      repo_id: data.repoId,
+      git_remote_url: data.gitRemoteUrl || null,
+      branch: data.branch || null,
+      commit_hash: data.commitHash || null,
+      working_tree_dirty: data.workingTreeDirty || false,
+      total_files: data.totalFiles || null,
+      cycle_count: data.cycleCount || null,
+      created_at: new Date(),
+    };
+
+    await this.knex(SnapshotRepository.TABLE_NAME).insert({
+      id: record.id,
+      repo_id: record.repo_id,
+      git_remote_url: record.git_remote_url,
+      branch: record.branch,
+      commit_hash: record.commit_hash,
+      working_tree_dirty: record.working_tree_dirty,
+      total_files: record.total_files,
+      cycle_count: record.cycle_count,
+      created_at: record.created_at,
+    });
+
+    return record;
+  }
+
+  /**
+   * Get a snapshot by ID
+   * @param id - The snapshot ID
+   * @returns The snapshot record or undefined if not found
+   */
+  async getSnapshotById(id: string): Promise<SnapshotRecord | undefined> {
+    const rows = await this.knex(SnapshotRepository.TABLE_NAME)
+      .where({ id })
+      .select('*');
+    
+    return rows[0] as SnapshotRecord | undefined;
+  }
+
+  /**
+   * Get the latest snapshot for a repo
+   * @param repoId - The repo ID
+   * @returns The latest snapshot record or undefined if not found
+   */
+  async getLatestSnapshot(repoId: string): Promise<SnapshotRecord | undefined> {
+    const rows = await this.knex(SnapshotRepository.TABLE_NAME)
+      .where({ repo_id: repoId })
+      .orderBy('created_at', 'desc')
+      .limit(1)
+      .select('*');
+    
+    return rows[0] as SnapshotRecord | undefined;
+  }
+
+  /**
+   * Get the two most recent snapshots for a repo (for drift comparison)
+   * @param repoId - The repo ID
+   * @returns Array of up to 2 snapshot records (most recent first)
+   */
+  async getRecentSnapshots(repoId: string): Promise<SnapshotRecord[]> {
+    const rows = await this.knex(SnapshotRepository.TABLE_NAME)
+      .where({ repo_id: repoId })
+      .orderBy('created_at', 'desc')
+      .limit(2)
+      .select('*');
+    
+    return rows as SnapshotRecord[];
+  }
+
+  /**
+   * Get all snapshots for a repo
+   * @param repoId - The repo ID
+   * @returns Array of snapshot records
+   */
+  async getSnapshotsByRepoId(repoId: string): Promise<SnapshotRecord[]> {
+    const rows = await this.knex(SnapshotRepository.TABLE_NAME)
+      .where({ repo_id: repoId })
+      .orderBy('created_at', 'desc')
+      .select('*');
+    
+    return rows as SnapshotRecord[];
+  }
+
+  /**
+   * Get snapshots by branch
+   * @param repoId - The repo ID
+   * @param branch - The branch name
+   * @returns Array of snapshot records
+   */
+  async getSnapshotsByBranch(repoId: string, branch: string): Promise<SnapshotRecord[]> {
+    const rows = await this.knex(SnapshotRepository.TABLE_NAME)
+      .where({ repo_id: repoId, branch })
+      .orderBy('created_at', 'desc')
+      .select('*');
+    
+    return rows as SnapshotRecord[];
+  }
+
+  /**
+   * Count snapshots for a repo
+   * @param repoId - The repo ID
+   * @returns The count of snapshots
+   */
+  async countSnapshots(repoId: string): Promise<number> {
+    const result = await this.knex(SnapshotRepository.TABLE_NAME)
+      .where({ repo_id: repoId })
+      .count('* as count')
+      .first();
+    
+    return Number(result?.count || 0);
+  }
+
+  /**
+   * Delete a snapshot by ID (cascades to related tables)
+   * @param id - The snapshot ID
+   */
+  async deleteSnapshot(id: string): Promise<void> {
+    await this.knex(SnapshotRepository.TABLE_NAME).where({ id }).delete();
+  }
+}

--- a/packages/engine/src/persistence/schema/001_init_schema.sql
+++ b/packages/engine/src/persistence/schema/001_init_schema.sql
@@ -1,0 +1,64 @@
+-- RepoStem Database Schema v1
+-- Compatible with both SQLite and PostgreSQL
+
+-- Enable foreign keys for SQLite (ignored by PostgreSQL)
+PRAGMA foreign_keys = ON;
+
+-- Repository table: stores repo metadata
+CREATE TABLE IF NOT EXISTS repo (
+    id TEXT PRIMARY KEY,
+    root_path TEXT NOT NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+-- Snapshot table: stores structural snapshots of the repository
+CREATE TABLE IF NOT EXISTS snapshot (
+    id TEXT PRIMARY KEY,
+    repo_id TEXT NOT NULL,
+    git_remote_url TEXT,
+    branch TEXT,
+    commit_hash TEXT,
+    working_tree_dirty BOOLEAN DEFAULT FALSE,
+    total_files INTEGER,
+    cycle_count INTEGER,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (repo_id) REFERENCES repo(id) ON DELETE CASCADE
+);
+
+-- File snapshot table: stores per-file metrics for each snapshot
+CREATE TABLE IF NOT EXISTS file_snapshot (
+    snapshot_id TEXT NOT NULL,
+    file_path TEXT NOT NULL,
+    dependency_importance REAL,
+    connectivity REAL,
+    churn REAL,
+    risk_score REAL,
+    risk_level TEXT CHECK (risk_level IN ('HIGH', 'MEDIUM', 'LOW')),
+    impact_count INTEGER DEFAULT 0,
+    PRIMARY KEY (snapshot_id, file_path),
+    FOREIGN KEY (snapshot_id) REFERENCES snapshot(id) ON DELETE CASCADE
+);
+
+-- Dependency edge table: stores file-to-file dependency edges
+CREATE TABLE IF NOT EXISTS dependency_edge (
+    snapshot_id TEXT NOT NULL,
+    from_file TEXT NOT NULL,
+    to_file TEXT NOT NULL,
+    PRIMARY KEY (snapshot_id, from_file, to_file),
+    FOREIGN KEY (snapshot_id) REFERENCES snapshot(id) ON DELETE CASCADE
+);
+
+-- Cycle table: stores detected cycles
+CREATE TABLE IF NOT EXISTS cycle (
+    id TEXT PRIMARY KEY,
+    snapshot_id TEXT NOT NULL,
+    nodes TEXT NOT NULL,
+    FOREIGN KEY (snapshot_id) REFERENCES snapshot(id) ON DELETE CASCADE
+);
+
+-- Indexes for common query patterns
+CREATE INDEX IF NOT EXISTS idx_snapshot_repo_id ON snapshot(repo_id);
+CREATE INDEX IF NOT EXISTS idx_snapshot_created_at ON snapshot(created_at);
+CREATE INDEX IF NOT EXISTS idx_file_snapshot_snapshot_id ON file_snapshot(snapshot_id);
+CREATE INDEX IF NOT EXISTS idx_dependency_edge_snapshot_id ON dependency_edge(snapshot_id);
+CREATE INDEX IF NOT EXISTS idx_cycle_snapshot_id ON cycle(snapshot_id);

--- a/packages/engine/src/types.ts
+++ b/packages/engine/src/types.ts
@@ -103,7 +103,25 @@ export enum MetricClassification {
     HIGH = "high"
 }
 
+export type StorageType = 'sqlite' | 'postgresql';
+
 export interface RepoStemConfig {
   ignore?: string[];
   respectGitignore?: boolean;
+  storage_type?: StorageType;
+  storage_path?: string;
+  repo_id?: string;
+}
+
+export interface ResetPersistenceResult {
+  success: boolean;
+  message: string;
+  snapshotsDeleted: number;
+}
+
+export interface MetricConfig {
+    key: string;
+    extractValue: (fileAnalysis: FileAnalysis, metrics: any) => number;
+    threshold?: number;
+    sortDescending?: boolean;
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,6 +35,9 @@ importers:
       dotenv:
         specifier: ^17.4.1
         version: 17.4.1
+      inquirer:
+        specifier: ^12.6.0
+        version: 12.11.1(@types/node@22.19.15)
       lodash:
         specifier: ^4.18.0
         version: 4.18.0
@@ -44,6 +47,9 @@ importers:
       '@types/lodash':
         specifier: ^4.17.24
         version: 4.17.24
+      knex:
+        specifier: ^3.1.0
+        version: 3.2.9(pg@8.20.0)(sqlite3@5.1.7)
       lodash:
         specifier: ^4.18.0
         version: 4.18.0
@@ -52,10 +58,16 @@ importers:
         version: 10.2.5
       openai:
         specifier: ^4.77.3
-        version: 4.104.0
+        version: 4.104.0(encoding@0.1.13)
+      pg:
+        specifier: ^8.14.1
+        version: 8.20.0
       simple-git:
         specifier: ^3.35.2
         version: 3.35.2
+      sqlite3:
+        specifier: ^5.1.7
+        version: 5.1.7
       tree-sitter:
         specifier: ^0.21.1
         version: 0.21.1
@@ -69,6 +81,9 @@ importers:
         specifier: ^10.9.2
         version: 10.9.2(@types/node@22.19.15)(typescript@5.9.3)
     devDependencies:
+      '@types/knex':
+        specifier: ^0.0.38
+        version: 0.0.38
       vitest:
         specifier: ^4.1.2
         version: 4.1.2(@types/node@22.19.15)(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@22.19.15))
@@ -147,8 +162,136 @@ packages:
   '@emnapi/wasi-threads@1.2.1':
     resolution: {integrity: sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==}
 
+  '@gar/promisify@1.1.3':
+    resolution: {integrity: sha512-k2Ty1JcVojjJFwrg/ThKi2ujJ7XNLYaFGNB/bWT9wGR+oSMJHMa5w+CUq6p/pVrKeNNgA7pCqEcjSnHVoqJQFw==}
+
+  '@inquirer/ansi@1.0.2':
+    resolution: {integrity: sha512-S8qNSZiYzFd0wAcyG5AXCvUHC5Sr7xpZ9wZ2py9XR88jUz8wooStVx5M6dRzczbBWjic9NP7+rY0Xi7qqK/aMQ==}
+    engines: {node: '>=18'}
+
+  '@inquirer/checkbox@4.3.2':
+    resolution: {integrity: sha512-VXukHf0RR1doGe6Sm4F0Em7SWYLTHSsbGfJdS9Ja2bX5/D5uwVOEjr07cncLROdBvmnvCATYEWlHqYmXv2IlQA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/confirm@5.1.21':
+    resolution: {integrity: sha512-KR8edRkIsUayMXV+o3Gv+q4jlhENF9nMYUZs9PA2HzrXeHI8M5uDag70U7RJn9yyiMZSbtF5/UexBtAVtZGSbQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/core@10.3.2':
+    resolution: {integrity: sha512-43RTuEbfP8MbKzedNqBrlhhNKVwoK//vUFNW3Q3vZ88BLcrs4kYpGg+B2mm5p2K/HfygoCxuKwJJiv8PbGmE0A==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/editor@4.2.23':
+    resolution: {integrity: sha512-aLSROkEwirotxZ1pBaP8tugXRFCxW94gwrQLxXfrZsKkfjOYC1aRvAZuhpJOb5cu4IBTJdsCigUlf2iCOu4ZDQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/expand@4.0.23':
+    resolution: {integrity: sha512-nRzdOyFYnpeYTTR2qFwEVmIWypzdAx/sIkCMeTNTcflFOovfqUk+HcFhQQVBftAh9gmGrpFj6QcGEqrDMDOiew==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
   '@inquirer/external-editor@1.0.3':
     resolution: {integrity: sha512-RWbSrDiYmO4LbejWY7ttpxczuwQyZLBUyygsA9Nsv95hpzUWwnNTVQmAq3xuh7vNwCp07UTmE5i11XAEExx4RA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/figures@1.0.15':
+    resolution: {integrity: sha512-t2IEY+unGHOzAaVM5Xx6DEWKeXlDDcNPeDyUpsRc6CUhBfU3VQOEl+Vssh7VNp1dR8MdUJBWhuObjXCsVpjN5g==}
+    engines: {node: '>=18'}
+
+  '@inquirer/input@4.3.1':
+    resolution: {integrity: sha512-kN0pAM4yPrLjJ1XJBjDxyfDduXOuQHrBB8aLDMueuwUGn+vNpF7Gq7TvyVxx8u4SHlFFj4trmj+a2cbpG4Jn1g==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/number@3.0.23':
+    resolution: {integrity: sha512-5Smv0OK7K0KUzUfYUXDXQc9jrf8OHo4ktlEayFlelCjwMXz0299Y8OrI+lj7i4gCBY15UObk76q0QtxjzFcFcg==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/password@4.0.23':
+    resolution: {integrity: sha512-zREJHjhT5vJBMZX/IUbyI9zVtVfOLiTO66MrF/3GFZYZ7T4YILW5MSkEYHceSii/KtRk+4i3RE7E1CUXA2jHcA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/prompts@7.10.1':
+    resolution: {integrity: sha512-Dx/y9bCQcXLI5ooQ5KyvA4FTgeo2jYj/7plWfV5Ak5wDPKQZgudKez2ixyfz7tKXzcJciTxqLeK7R9HItwiByg==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/rawlist@4.1.11':
+    resolution: {integrity: sha512-+LLQB8XGr3I5LZN/GuAHo+GpDJegQwuPARLChlMICNdwW7OwV2izlCSCxN6cqpL0sMXmbKbFcItJgdQq5EBXTw==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/search@3.2.2':
+    resolution: {integrity: sha512-p2bvRfENXCZdWF/U2BXvnSI9h+tuA8iNqtUKb9UWbmLYCRQxd8WkvwWvYn+3NgYaNwdUkHytJMGG4MMLucI1kA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/select@4.4.2':
+    resolution: {integrity: sha512-l4xMuJo55MAe+N7Qr4rX90vypFwCajSakx59qe/tMaC1aEHWLyw68wF4o0A4SLAY4E0nd+Vt+EyskeDIqu1M6w==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/type@3.0.10':
+    resolution: {integrity: sha512-BvziSRxfz5Ov8ch0z/n3oijRSEcEsHnhggm4xFZe93DHcUCTlutlq9Ox4SVENAfcRD22UQq7T/atg9Wr3k09eA==}
     engines: {node: '>=18'}
     peerDependencies:
       '@types/node': '>=18'
@@ -195,6 +338,14 @@ packages:
   '@nodelib/fs.walk@1.2.8':
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
+
+  '@npmcli/fs@1.1.1':
+    resolution: {integrity: sha512-8KG5RD0GVP4ydEzRn/I4BNDuxDtqVbOdm8675T49OIG/NGhaK0pjPX7ZcDlvKYbA+ulvVK3ztfcF4uBdOxuJbQ==}
+
+  '@npmcli/move-file@1.1.2':
+    resolution: {integrity: sha512-1SUf/Cg2GzGDyaf15aR9St9TWlb+XvbZXWpDx8YKs7MLzMH/BCeopv+y9vzrzgkfykCGuWOlSu3mZhj2+FQcrg==}
+    engines: {node: '>=10'}
+    deprecated: This functionality has been moved to @npmcli/fs
 
   '@oxc-project/types@0.122.0':
     resolution: {integrity: sha512-oLAl5kBpV4w69UtFZ9xqcmTi+GENWOcPF7FCrczTiBbmC0ibXxCwyvZGbO39rCVEuLGAZM84DH0pUIyyv/YJzA==}
@@ -300,6 +451,10 @@ packages:
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
+  '@tootallnate/once@1.1.2':
+    resolution: {integrity: sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==}
+    engines: {node: '>= 6'}
+
   '@tsconfig/node10@1.0.12':
     resolution: {integrity: sha512-UCYBaeFvM11aU2y3YPZ//O5Rhj+xKyzy7mvcIoAjASbigy8mHMryP5cK7dgjlz2hWxh1g5pLw084E0a/wlUSFQ==}
 
@@ -315,6 +470,9 @@ packages:
   '@tybys/wasm-util@0.10.1':
     resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==}
 
+  '@types/bluebird@3.5.42':
+    resolution: {integrity: sha512-Jhy+MWRlro6UjVi578V/4ZGNfeCOcNCp0YaFNIUGFKlImowqwb1O/22wDVk3FDGMLqxdpOV3qQHD5fPEH4hK6A==}
+
   '@types/chai@5.2.3':
     resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
 
@@ -323,6 +481,9 @@ packages:
 
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
+
+  '@types/knex@0.0.38':
+    resolution: {integrity: sha512-sKu6Q86bFri7cPd5OLolhtzyHa9TaHZPgv++1m0YUD0McgnmcwePAevb3evi0tcpf4CT6dfbVtr+0vJGWFTMGw==}
 
   '@types/lodash@4.17.24':
     resolution: {integrity: sha512-gIW7lQLZbue7lRSWEFql49QJJWThrTFFeIMJdp3eH4tKoxm1OvEPg02rm4wCCSHS0cL3/Fizimb35b7k8atwsQ==}
@@ -368,6 +529,9 @@ packages:
   '@vitest/utils@4.1.2':
     resolution: {integrity: sha512-xw2/TiX82lQHA06cgbqRKFb5lCAy3axQ4H4SoUFhUsg+wztiet+co86IAMDtF6Vm1hc7J6j09oh/rgDn+JdKIQ==}
 
+  abbrev@1.1.1:
+    resolution: {integrity: sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==}
+
   abort-controller@3.0.0:
     resolution: {integrity: sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==}
     engines: {node: '>=6.5'}
@@ -381,9 +545,17 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
+  agent-base@6.0.2:
+    resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
+    engines: {node: '>= 6.0.0'}
+
   agentkeepalive@4.6.0:
     resolution: {integrity: sha512-kja8j7PjmncONqaTsB8fQ+wE2mSU2DJ9D4XKoJ5PFWIdRMa6SLSN1ff4mOr4jCbfRSsxR4keIiySJU0N9T5hIQ==}
     engines: {node: '>= 8.0.0'}
+
+  aggregate-error@3.1.0:
+    resolution: {integrity: sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==}
+    engines: {node: '>=8'}
 
   ansi-colors@4.1.3:
     resolution: {integrity: sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==}
@@ -392,6 +564,18 @@ packages:
   ansi-regex@5.0.1:
     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
     engines: {node: '>=8'}
+
+  ansi-styles@4.3.0:
+    resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
+    engines: {node: '>=8'}
+
+  aproba@2.1.0:
+    resolution: {integrity: sha512-tLIEcj5GuR2RSTnxNKdkK0dJ/GrC7P38sUkiDmDuHfsHmbagTFAxDVIBltoklXEVIQ/f14IL8IMJ5pn9Hez1Ew==}
+
+  are-we-there-yet@3.0.1:
+    resolution: {integrity: sha512-QZW4EDmGwlYur0Yyf/b2uGucHQMa8aFUP7eu9ddR73vvhFyt4V0Vl3QHPcTNJ8l6qYOBdxgXdnBXQrHilfRQBg==}
+    engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
+    deprecated: This package is no longer supported.
 
   arg@4.1.3:
     resolution: {integrity: sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==}
@@ -413,13 +597,28 @@ packages:
   asynckit@0.4.0:
     resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
 
+  balanced-match@1.0.2:
+    resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
+
   balanced-match@4.0.4:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
     engines: {node: 18 || 20 || >=22}
 
+  base64-js@1.5.1:
+    resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
+
   better-path-resolve@1.0.0:
     resolution: {integrity: sha512-pbnl5XzGBdrFU/wT4jqmJVPn2B6UHPBOhzMQkY/SPUPB6QtUXtmBHBIwCbXJol93mOpGMnQyP/+BB19q04xj7g==}
     engines: {node: '>=4'}
+
+  bindings@1.5.0:
+    resolution: {integrity: sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==}
+
+  bl@4.1.0:
+    resolution: {integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==}
+
+  brace-expansion@1.1.14:
+    resolution: {integrity: sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==}
 
   brace-expansion@5.0.5:
     resolution: {integrity: sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==}
@@ -428,6 +627,13 @@ packages:
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
     engines: {node: '>=8'}
+
+  buffer@5.7.1:
+    resolution: {integrity: sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==}
+
+  cacache@15.3.0:
+    resolution: {integrity: sha512-VVdYzXEn+cnbXpFgWs5hTT7OScegHVmLhJIR8Ufqk3iFD6A6j5iSX1KuBTfNEv4tdJWE2PzA6IVFtcLC7fN9wQ==}
+    engines: {node: '>= 10'}
 
   call-bind-apply-helpers@1.0.2:
     resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
@@ -444,13 +650,52 @@ packages:
   chardet@2.1.1:
     resolution: {integrity: sha512-PsezH1rqdV9VvyNhxxOW32/d75r01NY7TQCmOqomRo15ZSOKbpTFVsfjghxo6JloQUCGnH4k1LGu0R4yCLlWQQ==}
 
+  chownr@1.1.4:
+    resolution: {integrity: sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==}
+
+  chownr@2.0.0:
+    resolution: {integrity: sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==}
+    engines: {node: '>=10'}
+
+  clean-stack@2.2.0:
+    resolution: {integrity: sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==}
+    engines: {node: '>=6'}
+
+  cli-width@4.1.0:
+    resolution: {integrity: sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==}
+    engines: {node: '>= 12'}
+
+  color-convert@2.0.1:
+    resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
+    engines: {node: '>=7.0.0'}
+
+  color-name@1.1.4:
+    resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
+
+  color-support@1.1.3:
+    resolution: {integrity: sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==}
+    hasBin: true
+
+  colorette@2.0.19:
+    resolution: {integrity: sha512-3tlv/dIP7FWvj3BsbHrGLJ6l/oKh1O3TcgBqMn+yyCagOxc23fyzDS6HypQbgxWbkpDnf52p1LuR4eWDQ/K9WQ==}
+
   combined-stream@1.0.8:
     resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
     engines: {node: '>= 0.8'}
 
+  commander@10.0.1:
+    resolution: {integrity: sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==}
+    engines: {node: '>=14'}
+
   commander@14.0.3:
     resolution: {integrity: sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==}
     engines: {node: '>=20'}
+
+  concat-map@0.0.1:
+    resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
+
+  console-control-strings@1.1.0:
+    resolution: {integrity: sha512-ty/fTekppD2fIwRvnZAVdeOiGd1c7YXEixbgJTNzqcxJWKQnjJ/V1bNEEE6hygpM3WjwHFUVK6HTjWSzV4a8sQ==}
 
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
@@ -462,6 +707,15 @@ packages:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
 
+  debug@4.3.4:
+    resolution: {integrity: sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
   debug@4.4.3:
     resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
     engines: {node: '>=6.0'}
@@ -471,9 +725,20 @@ packages:
       supports-color:
         optional: true
 
+  decompress-response@6.0.0:
+    resolution: {integrity: sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==}
+    engines: {node: '>=10'}
+
+  deep-extend@0.6.0:
+    resolution: {integrity: sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==}
+    engines: {node: '>=4.0.0'}
+
   delayed-stream@1.0.0:
     resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
     engines: {node: '>=0.4.0'}
+
+  delegates@1.0.0:
+    resolution: {integrity: sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ==}
 
   detect-indent@6.1.0:
     resolution: {integrity: sha512-reYkTUJAZb9gUuZ2RvVCNhVHdg62RHnJ7WJl8ftMi4diZ6NWlciOzQN88pUhSELEwflJht4oQDv0F0BMlwaYtA==}
@@ -499,9 +764,25 @@ packages:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
     engines: {node: '>= 0.4'}
 
+  emoji-regex@8.0.0:
+    resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
+
+  encoding@0.1.13:
+    resolution: {integrity: sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==}
+
+  end-of-stream@1.4.5:
+    resolution: {integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==}
+
   enquirer@2.4.1:
     resolution: {integrity: sha512-rRqJg/6gd538VHvR3PSrdRBb/1Vy2YfzHqzvbhGIQpDRKIa4FgV/54b5Q1xYSxOOwKvjXweS26E0Q+nAMwp2pQ==}
     engines: {node: '>=8.6'}
+
+  env-paths@2.2.1:
+    resolution: {integrity: sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==}
+    engines: {node: '>=6'}
+
+  err-code@2.0.3:
+    resolution: {integrity: sha512-2bmlRpNKBxT/CRmPOlyISQpNj+qSeYvcym/uT0Jx2bMOlKLtSy1ZmLuVxSEKKyor/N5yhvp/ZiG1oE3DEYMSFA==}
 
   es-define-property@1.0.1:
     resolution: {integrity: sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==}
@@ -522,6 +803,14 @@ packages:
     resolution: {integrity: sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==}
     engines: {node: '>= 0.4'}
 
+  escalade@3.2.0:
+    resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
+    engines: {node: '>=6'}
+
+  esm@3.2.25:
+    resolution: {integrity: sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA==}
+    engines: {node: '>=6'}
+
   esprima@4.0.1:
     resolution: {integrity: sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==}
     engines: {node: '>=4'}
@@ -532,6 +821,10 @@ packages:
 
   event-target-shim@5.0.1:
     resolution: {integrity: sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==}
+    engines: {node: '>=6'}
+
+  expand-template@2.0.3:
+    resolution: {integrity: sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==}
     engines: {node: '>=6'}
 
   expect-type@1.3.0:
@@ -557,6 +850,9 @@ packages:
       picomatch:
         optional: true
 
+  file-uri-to-path@1.0.0:
+    resolution: {integrity: sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==}
+
   fill-range@7.1.1:
     resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
     engines: {node: '>=8'}
@@ -576,6 +872,9 @@ packages:
     resolution: {integrity: sha512-0iirZp3uVDjVGt9p49aTaqjk84TrglENEDuqfdlZQ1roC9CWlPk6Avf8EEnZNcAqPonwkG35x4n3ww/1THYAeQ==}
     engines: {node: '>= 12.20'}
 
+  fs-constants@1.0.0:
+    resolution: {integrity: sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==}
+
   fs-extra@7.0.1:
     resolution: {integrity: sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==}
     engines: {node: '>=6 <7 || >=8'}
@@ -583,6 +882,13 @@ packages:
   fs-extra@8.1.0:
     resolution: {integrity: sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==}
     engines: {node: '>=6 <7 || >=8'}
+
+  fs-minipass@2.1.0:
+    resolution: {integrity: sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==}
+    engines: {node: '>= 8'}
+
+  fs.realpath@1.0.0:
+    resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
 
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
@@ -592,17 +898,36 @@ packages:
   function-bind@1.1.2:
     resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
 
+  gauge@4.0.4:
+    resolution: {integrity: sha512-f9m+BEN5jkg6a0fZjleidjN51VE1X+mPFQ2DJ0uv1V39oCLCbsGe6yjbBnp7eK7z/+GAon99a3nHuqbuuthyPg==}
+    engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
+    deprecated: This package is no longer supported.
+
   get-intrinsic@1.3.0:
     resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
     engines: {node: '>= 0.4'}
+
+  get-package-type@0.1.0:
+    resolution: {integrity: sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q==}
+    engines: {node: '>=8.0.0'}
 
   get-proto@1.0.1:
     resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
     engines: {node: '>= 0.4'}
 
+  getopts@2.3.0:
+    resolution: {integrity: sha512-5eDf9fuSXwxBL6q5HX+dhDj+dslFGWzU5thZ9kNKUkcPtaPdatmUFKwHFrLb/uf/WpA4BHET+AX3Scl56cAjpA==}
+
+  github-from-package@0.0.0:
+    resolution: {integrity: sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==}
+
   glob-parent@5.1.2:
     resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
     engines: {node: '>= 6'}
+
+  glob@7.2.3:
+    resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   globby@11.1.0:
     resolution: {integrity: sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==}
@@ -623,9 +948,23 @@ packages:
     resolution: {integrity: sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==}
     engines: {node: '>= 0.4'}
 
+  has-unicode@2.0.1:
+    resolution: {integrity: sha512-8Rf9Y83NBReMnx0gFzA8JImQACstCYWUplepDa9xprwwtmgEZUF0h/i5xSA625zB/I37EtrswSST6OXxwaaIJQ==}
+
   hasown@2.0.2:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
     engines: {node: '>= 0.4'}
+
+  http-cache-semantics@4.2.0:
+    resolution: {integrity: sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==}
+
+  http-proxy-agent@4.0.1:
+    resolution: {integrity: sha512-k0zdNgqWTGA6aeIRVpvfVob4fL52dTfaehylg0Y4UvSySvOq/Y+BOyPrgpUrA7HylqvU8vIZGsRuXmspskV0Tg==}
+    engines: {node: '>= 6'}
+
+  https-proxy-agent@5.0.1:
+    resolution: {integrity: sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==}
+    engines: {node: '>= 6'}
 
   human-id@4.1.3:
     resolution: {integrity: sha512-tsYlhAYpjCKa//8rXZ9DqKEawhPoSytweBC2eNvcaDK+57RZLHGqNs3PZTQO6yekLFSuvA6AlnAfrw1uBvtb+Q==}
@@ -634,21 +973,77 @@ packages:
   humanize-ms@1.2.1:
     resolution: {integrity: sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==}
 
+  iconv-lite@0.6.3:
+    resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
+    engines: {node: '>=0.10.0'}
+
   iconv-lite@0.7.2:
     resolution: {integrity: sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==}
     engines: {node: '>=0.10.0'}
+
+  ieee754@1.2.1:
+    resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
 
   ignore@5.3.2:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
     engines: {node: '>= 4'}
 
+  imurmurhash@0.1.4:
+    resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
+    engines: {node: '>=0.8.19'}
+
+  indent-string@4.0.0:
+    resolution: {integrity: sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==}
+    engines: {node: '>=8'}
+
+  infer-owner@1.0.4:
+    resolution: {integrity: sha512-IClj+Xz94+d7irH5qRyfJonOdfTzuDaifE6ZPWfx0N0+/ATZCbuTPq2prFl526urkQd90WyUKIh1DfBQ2hMz9A==}
+
+  inflight@1.0.6:
+    resolution: {integrity: sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==}
+    deprecated: This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.
+
+  inherits@2.0.4:
+    resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
+
+  ini@1.3.8:
+    resolution: {integrity: sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==}
+
+  inquirer@12.11.1:
+    resolution: {integrity: sha512-9VF7mrY+3OmsAfjH3yKz/pLbJ5z22E23hENKw3/LNSaA/sAt3v49bDRY+Ygct1xwuKT+U+cBfTzjCPySna69Qw==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  interpret@2.2.0:
+    resolution: {integrity: sha512-Ju0Bz/cEia55xDwUWEa8+olFpCiQoypjnQySseKtmjNrnps3P+xfpUmGr90T7yjlVJmOtybRvPXhKMbHr+fWnw==}
+    engines: {node: '>= 0.10'}
+
+  ip-address@10.1.0:
+    resolution: {integrity: sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==}
+    engines: {node: '>= 12'}
+
+  is-core-module@2.16.1:
+    resolution: {integrity: sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==}
+    engines: {node: '>= 0.4'}
+
   is-extglob@2.1.1:
     resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
     engines: {node: '>=0.10.0'}
 
+  is-fullwidth-code-point@3.0.0:
+    resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
+    engines: {node: '>=8'}
+
   is-glob@4.0.3:
     resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
     engines: {node: '>=0.10.0'}
+
+  is-lambda@1.0.1:
+    resolution: {integrity: sha512-z7CMFGNrENq5iFB9Bqo64Xk6Y9sg+epq1myIcdHaGnbMTYOxvzsEtdYqQUylB7LxfkvgrrjP32T6Ywciio9UIQ==}
 
   is-number@7.0.0:
     resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
@@ -675,6 +1070,37 @@ packages:
 
   jsonfile@4.0.0:
     resolution: {integrity: sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==}
+
+  knex@3.2.9:
+    resolution: {integrity: sha512-dtAILTjBMaG8YloP5oBxohDIKyIsdQ/TkcVvSjhsksvsjeH63Y0PADyuMDfNZKbVT3Rlx3vEYVBlecbPT/KerA==}
+    engines: {node: '>=16'}
+    hasBin: true
+    peerDependencies:
+      better-sqlite3: '*'
+      mysql: '*'
+      mysql2: '*'
+      pg: '*'
+      pg-native: '*'
+      pg-query-stream: ^4.14.0
+      sqlite3: '*'
+      tedious: '*'
+    peerDependenciesMeta:
+      better-sqlite3:
+        optional: true
+      mysql:
+        optional: true
+      mysql2:
+        optional: true
+      pg:
+        optional: true
+      pg-native:
+        optional: true
+      pg-query-stream:
+        optional: true
+      sqlite3:
+        optional: true
+      tedious:
+        optional: true
 
   lightningcss-android-arm64@1.32.0:
     resolution: {integrity: sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==}
@@ -757,11 +1183,19 @@ packages:
     resolution: {integrity: sha512-l1mfj2atMqndAHI3ls7XqPxEjV2J9ZkcNyHpoZA3r2T1LLwDB69jgkMWh71YKwhBbK0G2f4WSn05ahmQXVxupA==}
     deprecated: Bad release. Please use lodash@4.17.21 instead.
 
+  lru-cache@6.0.0:
+    resolution: {integrity: sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==}
+    engines: {node: '>=10'}
+
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
   make-error@1.3.6:
     resolution: {integrity: sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==}
+
+  make-fetch-happen@9.1.0:
+    resolution: {integrity: sha512-+zopwDy7DNknmwPQplem5lAZX/eCOzSvSNNcSKm5eVwTkOBzoktEfXsa9L23J/GIRhxRsaxzkPEhrJEpE2F4Gg==}
+    engines: {node: '>= 10'}
 
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
@@ -783,21 +1217,92 @@ packages:
     resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
     engines: {node: '>= 0.6'}
 
+  mimic-response@3.1.0:
+    resolution: {integrity: sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==}
+    engines: {node: '>=10'}
+
   minimatch@10.2.5:
     resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
     engines: {node: 18 || 20 || >=22}
+
+  minimatch@3.1.5:
+    resolution: {integrity: sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==}
+
+  minimist@1.2.8:
+    resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
+
+  minipass-collect@1.0.2:
+    resolution: {integrity: sha512-6T6lH0H8OG9kITm/Jm6tdooIbogG9e0tLgpY6mphXSm/A9u8Nq1ryBG+Qspiub9LjWlBPsPS3tWQ/Botq4FdxA==}
+    engines: {node: '>= 8'}
+
+  minipass-fetch@1.4.1:
+    resolution: {integrity: sha512-CGH1eblLq26Y15+Azk7ey4xh0J/XfJfrCox5LDJiKqI2Q2iwOLOKrlmIaODiSQS8d18jalF6y2K2ePUm0CmShw==}
+    engines: {node: '>=8'}
+
+  minipass-flush@1.0.7:
+    resolution: {integrity: sha512-TbqTz9cUwWyHS2Dy89P3ocAGUGxKjjLuR9z8w4WUTGAVgEj17/4nhgo2Du56i0Fm3Pm30g4iA8Lcqctc76jCzA==}
+    engines: {node: '>= 8'}
+
+  minipass-pipeline@1.2.4:
+    resolution: {integrity: sha512-xuIq7cIOt09RPRJ19gdi4b+RiNvDFYe5JH+ggNvBqGqpQXcru3PcRmOZuHBKWK1Txf9+cQ+HMVN4d6z46LZP7A==}
+    engines: {node: '>=8'}
+
+  minipass-sized@1.0.3:
+    resolution: {integrity: sha512-MbkQQ2CTiBMlA2Dm/5cY+9SWFEN8pzzOXi6rlM5Xxq0Yqbda5ZQy9sU75a673FE9ZK0Zsbr6Y5iP6u9nktfg2g==}
+    engines: {node: '>=8'}
+
+  minipass@3.3.6:
+    resolution: {integrity: sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==}
+    engines: {node: '>=8'}
+
+  minipass@5.0.0:
+    resolution: {integrity: sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==}
+    engines: {node: '>=8'}
+
+  minizlib@2.1.2:
+    resolution: {integrity: sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==}
+    engines: {node: '>= 8'}
+
+  mkdirp-classic@0.5.3:
+    resolution: {integrity: sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==}
+
+  mkdirp@1.0.4:
+    resolution: {integrity: sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==}
+    engines: {node: '>=10'}
+    hasBin: true
 
   mri@1.2.0:
     resolution: {integrity: sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==}
     engines: {node: '>=4'}
 
+  ms@2.1.2:
+    resolution: {integrity: sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==}
+
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+
+  mute-stream@2.0.0:
+    resolution: {integrity: sha512-WWdIxpyjEn+FhQJQQv9aQAYlHoNVdzIzUySNV1gHUPDSdZJ3yZn7pAAbQcV7B56Mvu881q9FZV+0Vx2xC44VWA==}
+    engines: {node: ^18.17.0 || >=20.5.0}
 
   nanoid@3.3.11:
     resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
+
+  napi-build-utils@2.0.0:
+    resolution: {integrity: sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==}
+
+  negotiator@0.6.4:
+    resolution: {integrity: sha512-myRT3DiWPHqho5PrJaIRyaMv2kgYf0mUVgBNOYMuCH5Ki1yEiQaf/ZJuQ62nvpc44wL5WDbTX7yGJi1Neevw8w==}
+    engines: {node: '>= 0.6'}
+
+  node-abi@3.89.0:
+    resolution: {integrity: sha512-6u9UwL0HlAl21+agMN3YAMXcKByMqwGx+pq+P76vii5f7hTPtKDp08/H9py6DY+cfDw7kQNTGEj/rly3IgbNQA==}
+    engines: {node: '>=10'}
+
+  node-addon-api@7.1.1:
+    resolution: {integrity: sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==}
 
   node-addon-api@8.7.0:
     resolution: {integrity: sha512-9MdFxmkKaOYVTV+XVRG8ArDwwQ77XIgIPyKASB1k3JPq3M8fGQQQE3YpMOrKm6g//Ktx8ivZr8xo1Qmtqub+GA==}
@@ -821,8 +1326,26 @@ packages:
     resolution: {integrity: sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==}
     hasBin: true
 
+  node-gyp@8.4.1:
+    resolution: {integrity: sha512-olTJRgUtAb/hOXG0E93wZDs5YiJlgbXxTwQAFHyNlRsXQnYzUaF2aGgujZbw+hR8aF4ZG/rST57bWMWD16jr9w==}
+    engines: {node: '>= 10.12.0'}
+    hasBin: true
+
+  nopt@5.0.0:
+    resolution: {integrity: sha512-Tbj67rffqceeLpcRXrT7vKAN8CwfPeIBgM7E6iBkmKLV7bEMwpGgYLGv0jACUsECaa/vuxP0IjEont6umdMgtQ==}
+    engines: {node: '>=6'}
+    hasBin: true
+
+  npmlog@6.0.2:
+    resolution: {integrity: sha512-/vBvz5Jfr9dT/aFWd0FIRf+T/Q2WBsLENygUaFUqstqsycmZAP/t5BvFJTK0viFmSUxiUKTUplWy5vt+rvKIxg==}
+    engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
+    deprecated: This package is no longer supported.
+
   obug@2.1.1:
     resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
+
+  once@1.4.0:
+    resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
 
   openai@4.104.0:
     resolution: {integrity: sha512-p99EFNsA/yX6UhVO93f5kJsDRLAg+CTA2RBqdHK4RtK8u5IJw32Hyb2dTGKbnnFmnuoBv5r7Z2CURI9sGZpSuA==}
@@ -855,6 +1378,10 @@ packages:
     resolution: {integrity: sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw==}
     engines: {node: '>=6'}
 
+  p-map@4.0.0:
+    resolution: {integrity: sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==}
+    engines: {node: '>=10'}
+
   p-try@2.2.0:
     resolution: {integrity: sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==}
     engines: {node: '>=6'}
@@ -866,9 +1393,16 @@ packages:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
     engines: {node: '>=8'}
 
+  path-is-absolute@1.0.1:
+    resolution: {integrity: sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==}
+    engines: {node: '>=0.10.0'}
+
   path-key@3.1.1:
     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
     engines: {node: '>=8'}
+
+  path-parse@1.0.7:
+    resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
 
   path-type@4.0.0:
     resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
@@ -876,6 +1410,43 @@ packages:
 
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+
+  pg-cloudflare@1.3.0:
+    resolution: {integrity: sha512-6lswVVSztmHiRtD6I8hw4qP/nDm1EJbKMRhf3HCYaqud7frGysPv7FYJ5noZQdhQtN2xJnimfMtvQq21pdbzyQ==}
+
+  pg-connection-string@2.12.0:
+    resolution: {integrity: sha512-U7qg+bpswf3Cs5xLzRqbXbQl85ng0mfSV/J0nnA31MCLgvEaAo7CIhmeyrmJpOr7o+zm0rXK+hNnT5l9RHkCkQ==}
+
+  pg-connection-string@2.6.2:
+    resolution: {integrity: sha512-ch6OwaeaPYcova4kKZ15sbJ2hKb/VP48ZD2gE7i1J+L4MspCtBMAx8nMgz7bksc7IojCIIWuEhHibSMFH8m8oA==}
+
+  pg-int8@1.0.1:
+    resolution: {integrity: sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==}
+    engines: {node: '>=4.0.0'}
+
+  pg-pool@3.13.0:
+    resolution: {integrity: sha512-gB+R+Xud1gLFuRD/QgOIgGOBE2KCQPaPwkzBBGC9oG69pHTkhQeIuejVIk3/cnDyX39av2AxomQiyPT13WKHQA==}
+    peerDependencies:
+      pg: '>=8.0'
+
+  pg-protocol@1.13.0:
+    resolution: {integrity: sha512-zzdvXfS6v89r6v7OcFCHfHlyG/wvry1ALxZo4LqgUoy7W9xhBDMaqOuMiF3qEV45VqsN6rdlcehHrfDtlCPc8w==}
+
+  pg-types@2.2.0:
+    resolution: {integrity: sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==}
+    engines: {node: '>=4'}
+
+  pg@8.20.0:
+    resolution: {integrity: sha512-ldhMxz2r8fl/6QkXnBD3CR9/xg694oT6DZQ2s6c/RI28OjtSOpxnPrUCGOBJ46RCUxcWdx3p6kw/xnDHjKvaRA==}
+    engines: {node: '>= 16.0.0'}
+    peerDependencies:
+      pg-native: '>=3.0.1'
+    peerDependenciesMeta:
+      pg-native:
+        optional: true
+
+  pgpass@1.0.5:
+    resolution: {integrity: sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==}
 
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
@@ -896,10 +1467,47 @@ packages:
     resolution: {integrity: sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==}
     engines: {node: ^10 || ^12 || >=14}
 
+  postgres-array@2.0.0:
+    resolution: {integrity: sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==}
+    engines: {node: '>=4'}
+
+  postgres-bytea@1.0.1:
+    resolution: {integrity: sha512-5+5HqXnsZPE65IJZSMkZtURARZelel2oXUEO8rH83VS/hxH5vv1uHquPg5wZs8yMAfdv971IU+kcPUczi7NVBQ==}
+    engines: {node: '>=0.10.0'}
+
+  postgres-date@1.0.7:
+    resolution: {integrity: sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==}
+    engines: {node: '>=0.10.0'}
+
+  postgres-interval@1.2.0:
+    resolution: {integrity: sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==}
+    engines: {node: '>=0.10.0'}
+
+  prebuild-install@7.1.3:
+    resolution: {integrity: sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==}
+    engines: {node: '>=10'}
+    deprecated: No longer maintained. Please contact the author of the relevant native addon; alternatives are available.
+    hasBin: true
+
   prettier@2.8.8:
     resolution: {integrity: sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==}
     engines: {node: '>=10.13.0'}
     hasBin: true
+
+  promise-inflight@1.0.1:
+    resolution: {integrity: sha512-6zWPyEOFaQBJYcGMHBKTKJ3u6TBsnMFOIZSa6ce1e/ZrrsOlnHRHbabMjLiBYKp+n44X9eUI6VUPaukCXHuG4g==}
+    peerDependencies:
+      bluebird: '*'
+    peerDependenciesMeta:
+      bluebird:
+        optional: true
+
+  promise-retry@2.0.1:
+    resolution: {integrity: sha512-y+WKFlBR8BGXnsNlIHFGPZmyDf3DFMoLhaflAnyZgV6rG6xu+JwesTo2Q9R6XwYmtmwAFCkAk3e35jEdoeh/3g==}
+    engines: {node: '>=10'}
+
+  pump@3.0.4:
+    resolution: {integrity: sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==}
 
   quansync@0.2.11:
     resolution: {integrity: sha512-AifT7QEbW9Nri4tAwR5M/uzpBuqfZf+zwaEM/QkzEjj7NBuFD2rBuy0K3dE+8wltbezDV7JMA0WfnCPYRSYbXA==}
@@ -907,25 +1515,61 @@ packages:
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
 
+  rc@1.2.8:
+    resolution: {integrity: sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==}
+    hasBin: true
+
   read-yaml-file@1.1.0:
     resolution: {integrity: sha512-VIMnQi/Z4HT2Fxuwg5KrY174U1VdUIASQVWXXyqtNRtxSr9IYkn1rsI6Tb6HsrHCmB7gVpNwX6JxPTHcH6IoTA==}
     engines: {node: '>=6'}
+
+  readable-stream@3.6.2:
+    resolution: {integrity: sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==}
+    engines: {node: '>= 6'}
+
+  rechoir@0.8.0:
+    resolution: {integrity: sha512-/vxpCXddiX8NGfGO/mTafwjq4aFa/71pvamip0++IQk3zG8cbCj0fifNPrjjF1XMXUne91jL9OoxmdykoEtifQ==}
+    engines: {node: '>= 10.13.0'}
 
   resolve-from@5.0.0:
     resolution: {integrity: sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==}
     engines: {node: '>=8'}
 
+  resolve@1.22.12:
+    resolution: {integrity: sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==}
+    engines: {node: '>= 0.4'}
+    hasBin: true
+
+  retry@0.12.0:
+    resolution: {integrity: sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==}
+    engines: {node: '>= 4'}
+
   reusify@1.1.0:
     resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
     engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
+
+  rimraf@3.0.2:
+    resolution: {integrity: sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==}
+    deprecated: Rimraf versions prior to v4 are no longer supported
+    hasBin: true
 
   rolldown@1.0.0-rc.12:
     resolution: {integrity: sha512-yP4USLIMYrwpPHEFB5JGH1uxhcslv6/hL0OyvTuY+3qlOSJvZ7ntYnoWpehBxufkgN0cvXxppuTu5hHa/zPh+A==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
 
+  run-async@4.0.6:
+    resolution: {integrity: sha512-IoDlSLTs3Yq593mb3ZoKWKXMNu3UpObxhgA/Xuid5p4bbfi2jdY1Hj0m1K+0/tEuQTxIGMhQDqGjKb7RuxGpAQ==}
+    engines: {node: '>=0.12.0'}
+
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
+
+  rxjs@7.8.2:
+    resolution: {integrity: sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==}
+
+  safe-buffer@5.2.1:
+    resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
 
   safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
@@ -934,6 +1578,9 @@ packages:
     resolution: {integrity: sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==}
     engines: {node: '>=10'}
     hasBin: true
+
+  set-blocking@2.0.0:
+    resolution: {integrity: sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==}
 
   shebang-command@2.0.0:
     resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
@@ -946,9 +1593,18 @@ packages:
   siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
 
+  signal-exit@3.0.7:
+    resolution: {integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==}
+
   signal-exit@4.1.0:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
     engines: {node: '>=14'}
+
+  simple-concat@1.0.1:
+    resolution: {integrity: sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==}
+
+  simple-get@4.0.1:
+    resolution: {integrity: sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==}
 
   simple-git@3.35.2:
     resolution: {integrity: sha512-ZMjl06lzTm1EScxEGuM6+mEX+NQd14h/B3x0vWU+YOXAMF8sicyi1K4cjTfj5is+35ChJEHDl1EjypzYFWH2FA==}
@@ -957,6 +1613,18 @@ packages:
     resolution: {integrity: sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==}
     engines: {node: '>=8'}
 
+  smart-buffer@4.2.0:
+    resolution: {integrity: sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==}
+    engines: {node: '>= 6.0.0', npm: '>= 3.0.0'}
+
+  socks-proxy-agent@6.2.1:
+    resolution: {integrity: sha512-a6KW9G+6B3nWZ1yB8G7pJwL3ggLy1uTzKAgCb7ttblwqdz9fMGJUuTy3uFzEP48FAs9FLILlmzDlE2JJhVQaXQ==}
+    engines: {node: '>= 10'}
+
+  socks@2.8.7:
+    resolution: {integrity: sha512-HLpt+uLy/pxB+bum/9DzAgiKS8CX1EvbWxI4zlmgGCExImLdiad2iCwXT5Z4c9c3Eq8rP2318mPW2c+QbtjK8A==}
+    engines: {node: '>= 10.0.0', npm: '>= 3.0.0'}
+
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
@@ -964,14 +1632,32 @@ packages:
   spawndamnit@3.0.1:
     resolution: {integrity: sha512-MmnduQUuHCoFckZoWnXsTg7JaiLBJrKFj9UI2MbRPGaJeVpsLcVBu6P/IGZovziM/YBsellCmsprgNA+w0CzVg==}
 
+  split2@4.2.0:
+    resolution: {integrity: sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==}
+    engines: {node: '>= 10.x'}
+
   sprintf-js@1.0.3:
     resolution: {integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==}
+
+  sqlite3@5.1.7:
+    resolution: {integrity: sha512-GGIyOiFaG+TUra3JIfkI/zGP8yZYLPQ0pl1bH+ODjiX57sPhrLU5sQJn1y9bDKZUFYkX1crlrPfSYt0BKKdkog==}
+
+  ssri@8.0.1:
+    resolution: {integrity: sha512-97qShzy1AiyxvPNIkLWoGua7xoQzzPjQ0HAH4B0rWKo7SZ6USuPcrUiAFrws0UH8RrbWmgq3LMTObhPIHbbBeQ==}
+    engines: {node: '>= 8'}
 
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
 
   std-env@4.0.0:
     resolution: {integrity: sha512-zUMPtQ/HBY3/50VbpkupYHbRroTRZJPRLvreamgErJVys0ceuzMkD44J/QjqhHjOzK42GQ3QZIeFG1OYfOtKqQ==}
+
+  string-width@4.2.3:
+    resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
+    engines: {node: '>=8'}
+
+  string_decoder@1.3.0:
+    resolution: {integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==}
 
   strip-ansi@6.0.1:
     resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
@@ -981,8 +1667,36 @@ packages:
     resolution: {integrity: sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==}
     engines: {node: '>=4'}
 
+  strip-json-comments@2.0.1:
+    resolution: {integrity: sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==}
+    engines: {node: '>=0.10.0'}
+
+  supports-preserve-symlinks-flag@1.0.0:
+    resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
+    engines: {node: '>= 0.4'}
+
+  tar-fs@2.1.4:
+    resolution: {integrity: sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==}
+
+  tar-stream@2.2.0:
+    resolution: {integrity: sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==}
+    engines: {node: '>=6'}
+
+  tar@6.2.1:
+    resolution: {integrity: sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==}
+    engines: {node: '>=10'}
+    deprecated: Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
+
+  tarn@3.0.2:
+    resolution: {integrity: sha512-51LAVKUSZSVfI05vjPESNc5vwqqZpbXCsU+/+wxlOrUjk2SnFTt97v9ZgQrD4YmxYW1Px6w2KjaDitCfkvgxMQ==}
+    engines: {node: '>=8.0.0'}
+
   term-size@2.2.1:
     resolution: {integrity: sha512-wK0Ri4fOGjv/XPy8SBHZChl8CM7uMc5VML7SqiQ0zG7+J5Vr+RMQDoHa2CNT6KHUnTGIXH34UDMkPzAUyapBZg==}
+    engines: {node: '>=8'}
+
+  tildify@2.0.0:
+    resolution: {integrity: sha512-Cc+OraorugtXNfs50hU9KS369rFXCfgGLpfCfvlc+Ud5u6VWmUQsOAa9HbTvheQdYnrdJqqv1e5oIqXppMYnSw==}
     engines: {node: '>=8'}
 
   tinybench@2.9.0:
@@ -1043,6 +1757,9 @@ packages:
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
+  tunnel-agent@0.6.0:
+    resolution: {integrity: sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==}
+
   typescript@5.9.3:
     resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
     engines: {node: '>=14.17'}
@@ -1054,9 +1771,18 @@ packages:
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
 
+  unique-filename@1.1.1:
+    resolution: {integrity: sha512-Vmp0jIp2ln35UTXuryvjzkjGdRyf9b2lTXuSYUiPmzRcl3FDtYqAwOnTJkAngD9SWhnoJzDbTKwaOrZ+STtxNQ==}
+
+  unique-slug@2.0.2:
+    resolution: {integrity: sha512-zoWr9ObaxALD3DOPfjPSqxt4fnZiWblxHIgeWqW8x7UqDzEtHEQLzji2cuJYQFCU6KmoJikOYAZlrTHHebjx2w==}
+
   universalify@0.1.2:
     resolution: {integrity: sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==}
     engines: {node: '>= 4.0.0'}
+
+  util-deprecate@1.0.2:
+    resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
 
   v8-compile-cache-lib@3.0.1:
     resolution: {integrity: sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==}
@@ -1159,9 +1885,30 @@ packages:
     engines: {node: '>=8'}
     hasBin: true
 
+  wide-align@1.1.5:
+    resolution: {integrity: sha512-eDMORYaPNZ4sQIuuYPDHdQvf4gyCF9rEEV/yPxGfwPkRodwEgiMUUXTx/dex+Me0wxx53S+NgUHaP7y3MGlDmg==}
+
+  wrap-ansi@6.2.0:
+    resolution: {integrity: sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==}
+    engines: {node: '>=8'}
+
+  wrappy@1.0.2:
+    resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
+
+  xtend@4.0.2:
+    resolution: {integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==}
+    engines: {node: '>=0.4'}
+
+  yallist@4.0.0:
+    resolution: {integrity: sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==}
+
   yn@3.1.1:
     resolution: {integrity: sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==}
     engines: {node: '>=6'}
+
+  yoctocolors-cjs@2.1.3:
+    resolution: {integrity: sha512-U/PBtDf35ff0D8X8D0jfdzHYEPFxAI7jJlxZXwCSez5M3190m+QobIfh+sWDWSHMCWWJN2AWamkegn6vr6YBTw==}
+    engines: {node: '>=18'}
 
 snapshots:
 
@@ -1330,10 +2077,131 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
+  '@gar/promisify@1.1.3':
+    optional: true
+
+  '@inquirer/ansi@1.0.2': {}
+
+  '@inquirer/checkbox@4.3.2(@types/node@22.19.15)':
+    dependencies:
+      '@inquirer/ansi': 1.0.2
+      '@inquirer/core': 10.3.2(@types/node@22.19.15)
+      '@inquirer/figures': 1.0.15
+      '@inquirer/type': 3.0.10(@types/node@22.19.15)
+      yoctocolors-cjs: 2.1.3
+    optionalDependencies:
+      '@types/node': 22.19.15
+
+  '@inquirer/confirm@5.1.21(@types/node@22.19.15)':
+    dependencies:
+      '@inquirer/core': 10.3.2(@types/node@22.19.15)
+      '@inquirer/type': 3.0.10(@types/node@22.19.15)
+    optionalDependencies:
+      '@types/node': 22.19.15
+
+  '@inquirer/core@10.3.2(@types/node@22.19.15)':
+    dependencies:
+      '@inquirer/ansi': 1.0.2
+      '@inquirer/figures': 1.0.15
+      '@inquirer/type': 3.0.10(@types/node@22.19.15)
+      cli-width: 4.1.0
+      mute-stream: 2.0.0
+      signal-exit: 4.1.0
+      wrap-ansi: 6.2.0
+      yoctocolors-cjs: 2.1.3
+    optionalDependencies:
+      '@types/node': 22.19.15
+
+  '@inquirer/editor@4.2.23(@types/node@22.19.15)':
+    dependencies:
+      '@inquirer/core': 10.3.2(@types/node@22.19.15)
+      '@inquirer/external-editor': 1.0.3(@types/node@22.19.15)
+      '@inquirer/type': 3.0.10(@types/node@22.19.15)
+    optionalDependencies:
+      '@types/node': 22.19.15
+
+  '@inquirer/expand@4.0.23(@types/node@22.19.15)':
+    dependencies:
+      '@inquirer/core': 10.3.2(@types/node@22.19.15)
+      '@inquirer/type': 3.0.10(@types/node@22.19.15)
+      yoctocolors-cjs: 2.1.3
+    optionalDependencies:
+      '@types/node': 22.19.15
+
   '@inquirer/external-editor@1.0.3(@types/node@22.19.15)':
     dependencies:
       chardet: 2.1.1
       iconv-lite: 0.7.2
+    optionalDependencies:
+      '@types/node': 22.19.15
+
+  '@inquirer/figures@1.0.15': {}
+
+  '@inquirer/input@4.3.1(@types/node@22.19.15)':
+    dependencies:
+      '@inquirer/core': 10.3.2(@types/node@22.19.15)
+      '@inquirer/type': 3.0.10(@types/node@22.19.15)
+    optionalDependencies:
+      '@types/node': 22.19.15
+
+  '@inquirer/number@3.0.23(@types/node@22.19.15)':
+    dependencies:
+      '@inquirer/core': 10.3.2(@types/node@22.19.15)
+      '@inquirer/type': 3.0.10(@types/node@22.19.15)
+    optionalDependencies:
+      '@types/node': 22.19.15
+
+  '@inquirer/password@4.0.23(@types/node@22.19.15)':
+    dependencies:
+      '@inquirer/ansi': 1.0.2
+      '@inquirer/core': 10.3.2(@types/node@22.19.15)
+      '@inquirer/type': 3.0.10(@types/node@22.19.15)
+    optionalDependencies:
+      '@types/node': 22.19.15
+
+  '@inquirer/prompts@7.10.1(@types/node@22.19.15)':
+    dependencies:
+      '@inquirer/checkbox': 4.3.2(@types/node@22.19.15)
+      '@inquirer/confirm': 5.1.21(@types/node@22.19.15)
+      '@inquirer/editor': 4.2.23(@types/node@22.19.15)
+      '@inquirer/expand': 4.0.23(@types/node@22.19.15)
+      '@inquirer/input': 4.3.1(@types/node@22.19.15)
+      '@inquirer/number': 3.0.23(@types/node@22.19.15)
+      '@inquirer/password': 4.0.23(@types/node@22.19.15)
+      '@inquirer/rawlist': 4.1.11(@types/node@22.19.15)
+      '@inquirer/search': 3.2.2(@types/node@22.19.15)
+      '@inquirer/select': 4.4.2(@types/node@22.19.15)
+    optionalDependencies:
+      '@types/node': 22.19.15
+
+  '@inquirer/rawlist@4.1.11(@types/node@22.19.15)':
+    dependencies:
+      '@inquirer/core': 10.3.2(@types/node@22.19.15)
+      '@inquirer/type': 3.0.10(@types/node@22.19.15)
+      yoctocolors-cjs: 2.1.3
+    optionalDependencies:
+      '@types/node': 22.19.15
+
+  '@inquirer/search@3.2.2(@types/node@22.19.15)':
+    dependencies:
+      '@inquirer/core': 10.3.2(@types/node@22.19.15)
+      '@inquirer/figures': 1.0.15
+      '@inquirer/type': 3.0.10(@types/node@22.19.15)
+      yoctocolors-cjs: 2.1.3
+    optionalDependencies:
+      '@types/node': 22.19.15
+
+  '@inquirer/select@4.4.2(@types/node@22.19.15)':
+    dependencies:
+      '@inquirer/ansi': 1.0.2
+      '@inquirer/core': 10.3.2(@types/node@22.19.15)
+      '@inquirer/figures': 1.0.15
+      '@inquirer/type': 3.0.10(@types/node@22.19.15)
+      yoctocolors-cjs: 2.1.3
+    optionalDependencies:
+      '@types/node': 22.19.15
+
+  '@inquirer/type@3.0.10(@types/node@22.19.15)':
     optionalDependencies:
       '@types/node': 22.19.15
 
@@ -1388,6 +2256,18 @@ snapshots:
     dependencies:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.20.1
+
+  '@npmcli/fs@1.1.1':
+    dependencies:
+      '@gar/promisify': 1.1.3
+      semver: 7.7.4
+    optional: true
+
+  '@npmcli/move-file@1.1.2':
+    dependencies:
+      mkdirp: 1.0.4
+      rimraf: 3.0.2
+    optional: true
 
   '@oxc-project/types@0.122.0': {}
 
@@ -1451,6 +2331,9 @@ snapshots:
 
   '@standard-schema/spec@1.1.0': {}
 
+  '@tootallnate/once@1.1.2':
+    optional: true
+
   '@tsconfig/node10@1.0.12': {}
 
   '@tsconfig/node12@1.0.11': {}
@@ -1464,6 +2347,8 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
+  '@types/bluebird@3.5.42': {}
+
   '@types/chai@5.2.3':
     dependencies:
       '@types/deep-eql': 4.0.2
@@ -1472,6 +2357,11 @@ snapshots:
   '@types/deep-eql@4.0.2': {}
 
   '@types/estree@1.0.8': {}
+
+  '@types/knex@0.0.38':
+    dependencies:
+      '@types/bluebird': 3.5.42
+      '@types/node': 22.19.15
 
   '@types/lodash@4.17.24': {}
 
@@ -1531,6 +2421,9 @@ snapshots:
       convert-source-map: 2.0.0
       tinyrainbow: 3.1.0
 
+  abbrev@1.1.1:
+    optional: true
+
   abort-controller@3.0.0:
     dependencies:
       event-target-shim: 5.0.1
@@ -1541,13 +2434,39 @@ snapshots:
 
   acorn@8.16.0: {}
 
+  agent-base@6.0.2:
+    dependencies:
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+    optional: true
+
   agentkeepalive@4.6.0:
     dependencies:
       humanize-ms: 1.2.1
 
+  aggregate-error@3.1.0:
+    dependencies:
+      clean-stack: 2.2.0
+      indent-string: 4.0.0
+    optional: true
+
   ansi-colors@4.1.3: {}
 
   ansi-regex@5.0.1: {}
+
+  ansi-styles@4.3.0:
+    dependencies:
+      color-convert: 2.0.1
+
+  aproba@2.1.0:
+    optional: true
+
+  are-we-there-yet@3.0.1:
+    dependencies:
+      delegates: 1.0.0
+      readable-stream: 3.6.2
+    optional: true
 
   arg@4.1.3: {}
 
@@ -1563,11 +2482,32 @@ snapshots:
 
   asynckit@0.4.0: {}
 
+  balanced-match@1.0.2:
+    optional: true
+
   balanced-match@4.0.4: {}
+
+  base64-js@1.5.1: {}
 
   better-path-resolve@1.0.0:
     dependencies:
       is-windows: 1.0.2
+
+  bindings@1.5.0:
+    dependencies:
+      file-uri-to-path: 1.0.0
+
+  bl@4.1.0:
+    dependencies:
+      buffer: 5.7.1
+      inherits: 2.0.4
+      readable-stream: 3.6.2
+
+  brace-expansion@1.1.14:
+    dependencies:
+      balanced-match: 1.0.2
+      concat-map: 0.0.1
+    optional: true
 
   brace-expansion@5.0.5:
     dependencies:
@@ -1576,6 +2516,35 @@ snapshots:
   braces@3.0.3:
     dependencies:
       fill-range: 7.1.1
+
+  buffer@5.7.1:
+    dependencies:
+      base64-js: 1.5.1
+      ieee754: 1.2.1
+
+  cacache@15.3.0:
+    dependencies:
+      '@npmcli/fs': 1.1.1
+      '@npmcli/move-file': 1.1.2
+      chownr: 2.0.0
+      fs-minipass: 2.1.0
+      glob: 7.2.3
+      infer-owner: 1.0.4
+      lru-cache: 6.0.0
+      minipass: 3.3.6
+      minipass-collect: 1.0.2
+      minipass-flush: 1.0.7
+      minipass-pipeline: 1.2.4
+      mkdirp: 1.0.4
+      p-map: 4.0.0
+      promise-inflight: 1.0.1
+      rimraf: 3.0.2
+      ssri: 8.0.1
+      tar: 6.2.1
+      unique-filename: 1.1.1
+    transitivePeerDependencies:
+      - bluebird
+    optional: true
 
   call-bind-apply-helpers@1.0.2:
     dependencies:
@@ -1588,11 +2557,39 @@ snapshots:
 
   chardet@2.1.1: {}
 
+  chownr@1.1.4: {}
+
+  chownr@2.0.0: {}
+
+  clean-stack@2.2.0:
+    optional: true
+
+  cli-width@4.1.0: {}
+
+  color-convert@2.0.1:
+    dependencies:
+      color-name: 1.1.4
+
+  color-name@1.1.4: {}
+
+  color-support@1.1.3:
+    optional: true
+
+  colorette@2.0.19: {}
+
   combined-stream@1.0.8:
     dependencies:
       delayed-stream: 1.0.0
 
+  commander@10.0.1: {}
+
   commander@14.0.3: {}
+
+  concat-map@0.0.1:
+    optional: true
+
+  console-control-strings@1.1.0:
+    optional: true
 
   convert-source-map@2.0.0: {}
 
@@ -1604,11 +2601,24 @@ snapshots:
       shebang-command: 2.0.0
       which: 2.0.2
 
+  debug@4.3.4:
+    dependencies:
+      ms: 2.1.2
+
   debug@4.4.3:
     dependencies:
       ms: 2.1.3
 
+  decompress-response@6.0.0:
+    dependencies:
+      mimic-response: 3.1.0
+
+  deep-extend@0.6.0: {}
+
   delayed-stream@1.0.0: {}
+
+  delegates@1.0.0:
+    optional: true
 
   detect-indent@6.1.0: {}
 
@@ -1628,10 +2638,27 @@ snapshots:
       es-errors: 1.3.0
       gopd: 1.2.0
 
+  emoji-regex@8.0.0: {}
+
+  encoding@0.1.13:
+    dependencies:
+      iconv-lite: 0.6.3
+    optional: true
+
+  end-of-stream@1.4.5:
+    dependencies:
+      once: 1.4.0
+
   enquirer@2.4.1:
     dependencies:
       ansi-colors: 4.1.3
       strip-ansi: 6.0.1
+
+  env-paths@2.2.1:
+    optional: true
+
+  err-code@2.0.3:
+    optional: true
 
   es-define-property@1.0.1: {}
 
@@ -1650,6 +2677,10 @@ snapshots:
       has-tostringtag: 1.0.2
       hasown: 2.0.2
 
+  escalade@3.2.0: {}
+
+  esm@3.2.25: {}
+
   esprima@4.0.1: {}
 
   estree-walker@3.0.3:
@@ -1657,6 +2688,8 @@ snapshots:
       '@types/estree': 1.0.8
 
   event-target-shim@5.0.1: {}
+
+  expand-template@2.0.3: {}
 
   expect-type@1.3.0: {}
 
@@ -1677,6 +2710,8 @@ snapshots:
   fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:
       picomatch: 4.0.4
+
+  file-uri-to-path@1.0.0: {}
 
   fill-range@7.1.1:
     dependencies:
@@ -1702,6 +2737,8 @@ snapshots:
       node-domexception: 1.0.0
       web-streams-polyfill: 4.0.0-beta.3
 
+  fs-constants@1.0.0: {}
+
   fs-extra@7.0.1:
     dependencies:
       graceful-fs: 4.2.11
@@ -1714,10 +2751,29 @@ snapshots:
       jsonfile: 4.0.0
       universalify: 0.1.2
 
+  fs-minipass@2.1.0:
+    dependencies:
+      minipass: 3.3.6
+
+  fs.realpath@1.0.0:
+    optional: true
+
   fsevents@2.3.3:
     optional: true
 
   function-bind@1.1.2: {}
+
+  gauge@4.0.4:
+    dependencies:
+      aproba: 2.1.0
+      color-support: 1.1.3
+      console-control-strings: 1.1.0
+      has-unicode: 2.0.1
+      signal-exit: 3.0.7
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+      wide-align: 1.1.5
+    optional: true
 
   get-intrinsic@1.3.0:
     dependencies:
@@ -1732,14 +2788,30 @@ snapshots:
       hasown: 2.0.2
       math-intrinsics: 1.1.0
 
+  get-package-type@0.1.0: {}
+
   get-proto@1.0.1:
     dependencies:
       dunder-proto: 1.0.1
       es-object-atoms: 1.1.1
 
+  getopts@2.3.0: {}
+
+  github-from-package@0.0.0: {}
+
   glob-parent@5.1.2:
     dependencies:
       is-glob: 4.0.3
+
+  glob@7.2.3:
+    dependencies:
+      fs.realpath: 1.0.0
+      inflight: 1.0.6
+      inherits: 2.0.4
+      minimatch: 3.1.5
+      once: 1.4.0
+      path-is-absolute: 1.0.1
+    optional: true
 
   globby@11.1.0:
     dependencies:
@@ -1760,9 +2832,32 @@ snapshots:
     dependencies:
       has-symbols: 1.1.0
 
+  has-unicode@2.0.1:
+    optional: true
+
   hasown@2.0.2:
     dependencies:
       function-bind: 1.1.2
+
+  http-cache-semantics@4.2.0:
+    optional: true
+
+  http-proxy-agent@4.0.1:
+    dependencies:
+      '@tootallnate/once': 1.1.2
+      agent-base: 6.0.2
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+    optional: true
+
+  https-proxy-agent@5.0.1:
+    dependencies:
+      agent-base: 6.0.2
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+    optional: true
 
   human-id@4.1.3: {}
 
@@ -1770,17 +2865,69 @@ snapshots:
     dependencies:
       ms: 2.1.3
 
+  iconv-lite@0.6.3:
+    dependencies:
+      safer-buffer: 2.1.2
+    optional: true
+
   iconv-lite@0.7.2:
     dependencies:
       safer-buffer: 2.1.2
 
+  ieee754@1.2.1: {}
+
   ignore@5.3.2: {}
 
+  imurmurhash@0.1.4:
+    optional: true
+
+  indent-string@4.0.0:
+    optional: true
+
+  infer-owner@1.0.4:
+    optional: true
+
+  inflight@1.0.6:
+    dependencies:
+      once: 1.4.0
+      wrappy: 1.0.2
+    optional: true
+
+  inherits@2.0.4: {}
+
+  ini@1.3.8: {}
+
+  inquirer@12.11.1(@types/node@22.19.15):
+    dependencies:
+      '@inquirer/ansi': 1.0.2
+      '@inquirer/core': 10.3.2(@types/node@22.19.15)
+      '@inquirer/prompts': 7.10.1(@types/node@22.19.15)
+      '@inquirer/type': 3.0.10(@types/node@22.19.15)
+      mute-stream: 2.0.0
+      run-async: 4.0.6
+      rxjs: 7.8.2
+    optionalDependencies:
+      '@types/node': 22.19.15
+
+  interpret@2.2.0: {}
+
+  ip-address@10.1.0:
+    optional: true
+
+  is-core-module@2.16.1:
+    dependencies:
+      hasown: 2.0.2
+
   is-extglob@2.1.1: {}
+
+  is-fullwidth-code-point@3.0.0: {}
 
   is-glob@4.0.3:
     dependencies:
       is-extglob: 2.1.1
+
+  is-lambda@1.0.1:
+    optional: true
 
   is-number@7.0.0: {}
 
@@ -1804,6 +2951,28 @@ snapshots:
   jsonfile@4.0.0:
     optionalDependencies:
       graceful-fs: 4.2.11
+
+  knex@3.2.9(pg@8.20.0)(sqlite3@5.1.7):
+    dependencies:
+      colorette: 2.0.19
+      commander: 10.0.1
+      debug: 4.3.4
+      escalade: 3.2.0
+      esm: 3.2.25
+      get-package-type: 0.1.0
+      getopts: 2.3.0
+      interpret: 2.2.0
+      lodash: 4.18.0
+      pg-connection-string: 2.6.2
+      rechoir: 0.8.0
+      resolve-from: 5.0.0
+      tarn: 3.0.2
+      tildify: 2.0.0
+    optionalDependencies:
+      pg: 8.20.0
+      sqlite3: 5.1.7
+    transitivePeerDependencies:
+      - supports-color
 
   lightningcss-android-arm64@1.32.0:
     optional: true
@@ -1862,11 +3031,39 @@ snapshots:
 
   lodash@4.18.0: {}
 
+  lru-cache@6.0.0:
+    dependencies:
+      yallist: 4.0.0
+    optional: true
+
   magic-string@0.30.21:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
 
   make-error@1.3.6: {}
+
+  make-fetch-happen@9.1.0:
+    dependencies:
+      agentkeepalive: 4.6.0
+      cacache: 15.3.0
+      http-cache-semantics: 4.2.0
+      http-proxy-agent: 4.0.1
+      https-proxy-agent: 5.0.1
+      is-lambda: 1.0.1
+      lru-cache: 6.0.0
+      minipass: 3.3.6
+      minipass-collect: 1.0.2
+      minipass-fetch: 1.4.1
+      minipass-flush: 1.0.7
+      minipass-pipeline: 1.2.4
+      negotiator: 0.6.4
+      promise-retry: 2.0.1
+      socks-proxy-agent: 6.2.1
+      ssri: 8.0.1
+    transitivePeerDependencies:
+      - bluebird
+      - supports-color
+    optional: true
 
   math-intrinsics@1.1.0: {}
 
@@ -1883,29 +3080,133 @@ snapshots:
     dependencies:
       mime-db: 1.52.0
 
+  mimic-response@3.1.0: {}
+
   minimatch@10.2.5:
     dependencies:
       brace-expansion: 5.0.5
 
+  minimatch@3.1.5:
+    dependencies:
+      brace-expansion: 1.1.14
+    optional: true
+
+  minimist@1.2.8: {}
+
+  minipass-collect@1.0.2:
+    dependencies:
+      minipass: 3.3.6
+    optional: true
+
+  minipass-fetch@1.4.1:
+    dependencies:
+      minipass: 3.3.6
+      minipass-sized: 1.0.3
+      minizlib: 2.1.2
+    optionalDependencies:
+      encoding: 0.1.13
+    optional: true
+
+  minipass-flush@1.0.7:
+    dependencies:
+      minipass: 3.3.6
+    optional: true
+
+  minipass-pipeline@1.2.4:
+    dependencies:
+      minipass: 3.3.6
+    optional: true
+
+  minipass-sized@1.0.3:
+    dependencies:
+      minipass: 3.3.6
+    optional: true
+
+  minipass@3.3.6:
+    dependencies:
+      yallist: 4.0.0
+
+  minipass@5.0.0: {}
+
+  minizlib@2.1.2:
+    dependencies:
+      minipass: 3.3.6
+      yallist: 4.0.0
+
+  mkdirp-classic@0.5.3: {}
+
+  mkdirp@1.0.4: {}
+
   mri@1.2.0: {}
+
+  ms@2.1.2: {}
 
   ms@2.1.3: {}
 
+  mute-stream@2.0.0: {}
+
   nanoid@3.3.11: {}
+
+  napi-build-utils@2.0.0: {}
+
+  negotiator@0.6.4:
+    optional: true
+
+  node-abi@3.89.0:
+    dependencies:
+      semver: 7.7.4
+
+  node-addon-api@7.1.1: {}
 
   node-addon-api@8.7.0: {}
 
   node-domexception@1.0.0: {}
 
-  node-fetch@2.7.0:
+  node-fetch@2.7.0(encoding@0.1.13):
     dependencies:
       whatwg-url: 5.0.0
+    optionalDependencies:
+      encoding: 0.1.13
 
   node-gyp-build@4.8.4: {}
 
+  node-gyp@8.4.1:
+    dependencies:
+      env-paths: 2.2.1
+      glob: 7.2.3
+      graceful-fs: 4.2.11
+      make-fetch-happen: 9.1.0
+      nopt: 5.0.0
+      npmlog: 6.0.2
+      rimraf: 3.0.2
+      semver: 7.7.4
+      tar: 6.2.1
+      which: 2.0.2
+    transitivePeerDependencies:
+      - bluebird
+      - supports-color
+    optional: true
+
+  nopt@5.0.0:
+    dependencies:
+      abbrev: 1.1.1
+    optional: true
+
+  npmlog@6.0.2:
+    dependencies:
+      are-we-there-yet: 3.0.1
+      console-control-strings: 1.1.0
+      gauge: 4.0.4
+      set-blocking: 2.0.0
+    optional: true
+
   obug@2.1.1: {}
 
-  openai@4.104.0:
+  once@1.4.0:
+    dependencies:
+      wrappy: 1.0.2
+
+  openai@4.104.0(encoding@0.1.13):
     dependencies:
       '@types/node': 18.19.130
       '@types/node-fetch': 2.6.13
@@ -1913,7 +3214,7 @@ snapshots:
       agentkeepalive: 4.6.0
       form-data-encoder: 1.7.2
       formdata-node: 4.4.1
-      node-fetch: 2.7.0
+      node-fetch: 2.7.0(encoding@0.1.13)
     transitivePeerDependencies:
       - encoding
 
@@ -1933,6 +3234,11 @@ snapshots:
 
   p-map@2.1.0: {}
 
+  p-map@4.0.0:
+    dependencies:
+      aggregate-error: 3.1.0
+    optional: true
+
   p-try@2.2.0: {}
 
   package-manager-detector@0.2.11:
@@ -1941,11 +3247,53 @@ snapshots:
 
   path-exists@4.0.0: {}
 
+  path-is-absolute@1.0.1:
+    optional: true
+
   path-key@3.1.1: {}
+
+  path-parse@1.0.7: {}
 
   path-type@4.0.0: {}
 
   pathe@2.0.3: {}
+
+  pg-cloudflare@1.3.0:
+    optional: true
+
+  pg-connection-string@2.12.0: {}
+
+  pg-connection-string@2.6.2: {}
+
+  pg-int8@1.0.1: {}
+
+  pg-pool@3.13.0(pg@8.20.0):
+    dependencies:
+      pg: 8.20.0
+
+  pg-protocol@1.13.0: {}
+
+  pg-types@2.2.0:
+    dependencies:
+      pg-int8: 1.0.1
+      postgres-array: 2.0.0
+      postgres-bytea: 1.0.1
+      postgres-date: 1.0.7
+      postgres-interval: 1.2.0
+
+  pg@8.20.0:
+    dependencies:
+      pg-connection-string: 2.12.0
+      pg-pool: 3.13.0(pg@8.20.0)
+      pg-protocol: 1.13.0
+      pg-types: 2.2.0
+      pgpass: 1.0.5
+    optionalDependencies:
+      pg-cloudflare: 1.3.0
+
+  pgpass@1.0.5:
+    dependencies:
+      split2: 4.2.0
 
   picocolors@1.1.1: {}
 
@@ -1961,11 +3309,57 @@ snapshots:
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
+  postgres-array@2.0.0: {}
+
+  postgres-bytea@1.0.1: {}
+
+  postgres-date@1.0.7: {}
+
+  postgres-interval@1.2.0:
+    dependencies:
+      xtend: 4.0.2
+
+  prebuild-install@7.1.3:
+    dependencies:
+      detect-libc: 2.1.2
+      expand-template: 2.0.3
+      github-from-package: 0.0.0
+      minimist: 1.2.8
+      mkdirp-classic: 0.5.3
+      napi-build-utils: 2.0.0
+      node-abi: 3.89.0
+      pump: 3.0.4
+      rc: 1.2.8
+      simple-get: 4.0.1
+      tar-fs: 2.1.4
+      tunnel-agent: 0.6.0
+
   prettier@2.8.8: {}
+
+  promise-inflight@1.0.1:
+    optional: true
+
+  promise-retry@2.0.1:
+    dependencies:
+      err-code: 2.0.3
+      retry: 0.12.0
+    optional: true
+
+  pump@3.0.4:
+    dependencies:
+      end-of-stream: 1.4.5
+      once: 1.4.0
 
   quansync@0.2.11: {}
 
   queue-microtask@1.2.3: {}
+
+  rc@1.2.8:
+    dependencies:
+      deep-extend: 0.6.0
+      ini: 1.3.8
+      minimist: 1.2.8
+      strip-json-comments: 2.0.1
 
   read-yaml-file@1.1.0:
     dependencies:
@@ -1974,9 +3368,34 @@ snapshots:
       pify: 4.0.1
       strip-bom: 3.0.0
 
+  readable-stream@3.6.2:
+    dependencies:
+      inherits: 2.0.4
+      string_decoder: 1.3.0
+      util-deprecate: 1.0.2
+
+  rechoir@0.8.0:
+    dependencies:
+      resolve: 1.22.12
+
   resolve-from@5.0.0: {}
 
+  resolve@1.22.12:
+    dependencies:
+      es-errors: 1.3.0
+      is-core-module: 2.16.1
+      path-parse: 1.0.7
+      supports-preserve-symlinks-flag: 1.0.0
+
+  retry@0.12.0:
+    optional: true
+
   reusify@1.1.0: {}
+
+  rimraf@3.0.2:
+    dependencies:
+      glob: 7.2.3
+    optional: true
 
   rolldown@1.0.0-rc.12(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2):
     dependencies:
@@ -2002,13 +3421,24 @@ snapshots:
       - '@emnapi/core'
       - '@emnapi/runtime'
 
+  run-async@4.0.6: {}
+
   run-parallel@1.2.0:
     dependencies:
       queue-microtask: 1.2.3
 
+  rxjs@7.8.2:
+    dependencies:
+      tslib: 2.8.1
+
+  safe-buffer@5.2.1: {}
+
   safer-buffer@2.1.2: {}
 
   semver@7.7.4: {}
+
+  set-blocking@2.0.0:
+    optional: true
 
   shebang-command@2.0.0:
     dependencies:
@@ -2018,7 +3448,18 @@ snapshots:
 
   siginfo@2.0.0: {}
 
+  signal-exit@3.0.7:
+    optional: true
+
   signal-exit@4.1.0: {}
+
+  simple-concat@1.0.1: {}
+
+  simple-get@4.0.1:
+    dependencies:
+      decompress-response: 6.0.0
+      once: 1.4.0
+      simple-concat: 1.0.1
 
   simple-git@3.35.2:
     dependencies:
@@ -2032,6 +3473,24 @@ snapshots:
 
   slash@3.0.0: {}
 
+  smart-buffer@4.2.0:
+    optional: true
+
+  socks-proxy-agent@6.2.1:
+    dependencies:
+      agent-base: 6.0.2
+      debug: 4.4.3
+      socks: 2.8.7
+    transitivePeerDependencies:
+      - supports-color
+    optional: true
+
+  socks@2.8.7:
+    dependencies:
+      ip-address: 10.1.0
+      smart-buffer: 4.2.0
+    optional: true
+
   source-map-js@1.2.1: {}
 
   spawndamnit@3.0.1:
@@ -2039,11 +3498,40 @@ snapshots:
       cross-spawn: 7.0.6
       signal-exit: 4.1.0
 
+  split2@4.2.0: {}
+
   sprintf-js@1.0.3: {}
+
+  sqlite3@5.1.7:
+    dependencies:
+      bindings: 1.5.0
+      node-addon-api: 7.1.1
+      prebuild-install: 7.1.3
+      tar: 6.2.1
+    optionalDependencies:
+      node-gyp: 8.4.1
+    transitivePeerDependencies:
+      - bluebird
+      - supports-color
+
+  ssri@8.0.1:
+    dependencies:
+      minipass: 3.3.6
+    optional: true
 
   stackback@0.0.2: {}
 
   std-env@4.0.0: {}
+
+  string-width@4.2.3:
+    dependencies:
+      emoji-regex: 8.0.0
+      is-fullwidth-code-point: 3.0.0
+      strip-ansi: 6.0.1
+
+  string_decoder@1.3.0:
+    dependencies:
+      safe-buffer: 5.2.1
 
   strip-ansi@6.0.1:
     dependencies:
@@ -2051,7 +3539,39 @@ snapshots:
 
   strip-bom@3.0.0: {}
 
+  strip-json-comments@2.0.1: {}
+
+  supports-preserve-symlinks-flag@1.0.0: {}
+
+  tar-fs@2.1.4:
+    dependencies:
+      chownr: 1.1.4
+      mkdirp-classic: 0.5.3
+      pump: 3.0.4
+      tar-stream: 2.2.0
+
+  tar-stream@2.2.0:
+    dependencies:
+      bl: 4.1.0
+      end-of-stream: 1.4.5
+      fs-constants: 1.0.0
+      inherits: 2.0.4
+      readable-stream: 3.6.2
+
+  tar@6.2.1:
+    dependencies:
+      chownr: 2.0.0
+      fs-minipass: 2.1.0
+      minipass: 5.0.0
+      minizlib: 2.1.2
+      mkdirp: 1.0.4
+      yallist: 4.0.0
+
+  tarn@3.0.2: {}
+
   term-size@2.2.1: {}
+
+  tildify@2.0.0: {}
 
   tinybench@2.9.0: {}
 
@@ -2108,8 +3628,11 @@ snapshots:
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
 
-  tslib@2.8.1:
-    optional: true
+  tslib@2.8.1: {}
+
+  tunnel-agent@0.6.0:
+    dependencies:
+      safe-buffer: 5.2.1
 
   typescript@5.9.3: {}
 
@@ -2117,7 +3640,19 @@ snapshots:
 
   undici-types@6.21.0: {}
 
+  unique-filename@1.1.1:
+    dependencies:
+      unique-slug: 2.0.2
+    optional: true
+
+  unique-slug@2.0.2:
+    dependencies:
+      imurmurhash: 0.1.4
+    optional: true
+
   universalify@0.1.2: {}
+
+  util-deprecate@1.0.2: {}
 
   v8-compile-cache-lib@3.0.1: {}
 
@@ -2180,4 +3715,23 @@ snapshots:
       siginfo: 2.0.0
       stackback: 0.0.2
 
+  wide-align@1.1.5:
+    dependencies:
+      string-width: 4.2.3
+    optional: true
+
+  wrap-ansi@6.2.0:
+    dependencies:
+      ansi-styles: 4.3.0
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+
+  wrappy@1.0.2: {}
+
+  xtend@4.0.2: {}
+
+  yallist@4.0.0: {}
+
   yn@3.1.1: {}
+
+  yoctocolors-cjs@2.1.3: {}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,7 +1,8 @@
 packages:
-  - 'apps/*'
-  - 'packages/*'
+  - apps/*
+  - packages/*
 ignoredBuiltDependencies:
+  - sqlite3
   - tree-sitter
   - tree-sitter-javascript
   - tree-sitter-typescript


### PR DESCRIPTION
# Implement Snapshot Persistence Configuration

## Overview
This PR implements the `repostem init` command and persistence layer for storing structural snapshots in a database (SQLite or PostgreSQL). This enables architectural drift detection, snapshot history tracking, and temporal analysis of repository structure.

**Issue**: [#12](https://github.com/mohamedwaleed/repostem/issues/12)

## Changes

### Core Engine (`packages/engine`)

#### New Persistence Layer
- **Database Adapters**: Abstract adapter pattern for database connections
  - `SQLiteAdapter`: SQLite database support
  - `PostgreSQLAdapter`: PostgreSQL database support
  - `AdapterFactory`: Factory for creating appropriate adapter instances
  - `DatabaseAdapter` interface: Common database operations interface

- **Schema Management**
  - SQL migration files for schema initialization
  - `001_init_schema.sql`: Creates tables for repo, snapshot, file_snapshot, dependency_edge, and cycle
  - Migration runner with support for both SQLite and PostgreSQL

- **Repository Layer**
  - `RepoRepository`: CRUD operations for repo records
  - `SnapshotRepository`: CRUD operations for snapshot records
  - Type-safe repository abstractions

- **Engine Functions**
  - `initializeRepo`: Initialize repository for persistence
    - Creates database schema
    - Generates unique repo_id (UUID)
    - Stores repo record in database
    - Supports reconfiguration with existing repo_id
  - `isRepoInitialized`: Check if repository is initialized
  - `resetPersistence`: Delete all snapshots while preserving repo record

#### Configuration Updates
- Added `repo_id` field to `RepoStemConfig` interface
- Added `storage_type` and `storage_path` fields for persistence configuration
- Updated config loader to support both `.repostem.json` and `repostem.config.json`
- Added `isPersistenceConfigured` helper function

#### Type Updates
- Added `InitRepoOptions` and `InitRepoResult` interfaces
- Added `ResetPersistenceResult` interface
- Added `StorageType` type (sqlite | postgresql)
- Added persistence-related exports

#### Tests
- Added comprehensive tests for persistence functions
- Tests for `initializeRepo` with new and existing repo_id
- Tests for `isRepoInitialized` and `resetPersistence`
- Updated config-loader tests to support alternative config file name

### CLI (`apps/cli`)

#### New `init` Command
- Interactive prompt for storage type selection (SQLite or PostgreSQL)
- Support for command-line flags (`--storage`, `--db-path`, `--repo`)
- Menu-driven interaction when config exists:
  - **Reconfigure storage backend**: Change storage type/path while preserving repo_id
  - **Reset persistence**: Delete all snapshots but keep repo record
  - **Cancel**: Exit without changes
- Validation of repo_id existence in database
- Preserves repo_id across storage reconfigurations to maintain repository identity

#### CLI Updates
- Added `InitOptions` interface for type safety
- Removed `--force` flag (replaced with menu-driven interaction)
- Updated CLI to use engine functions for initialization and reset

### Documentation

#### Main README.md
- Added `repostem init` to Quick Start
- Added `init` to CLI Commands list
- New "Persistence Configuration" section with usage examples
- Reconfiguration behavior documentation

#### CLI README.md
- Added complete `init` command documentation
- Included options, reconfiguration behavior, and examples

#### Engine README.md
- Added `initializeRepo`, `isRepoInitialized`, `resetPersistence` to API reference
- Added note about repo_id preservation during reconfiguration

#### Architecture v2
- Updated `repostem init` section with new menu behavior
- Added reconfiguration options documentation
- Added repo_id preservation behavior
- Added architectural principle about repo_id stability

## Breaking Changes
None. This is a new feature.

## Migration Guide
No migration needed. This is an opt-in feature via `repostem init`.

## Testing
- All existing tests pass (259 tests)
- Added new tests for persistence layer
- Added tests for config loader alternative file name support

## Database Schema
```sql
CREATE TABLE repo (
    id TEXT PRIMARY KEY,
    root_path TEXT NOT NULL,
    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
);

CREATE TABLE snapshot (
    id TEXT PRIMARY KEY,
    repo_id TEXT NOT NULL,
    git_remote_url TEXT,
    branch TEXT,
    commit_hash TEXT,
    working_tree_dirty BOOLEAN DEFAULT FALSE,
    total_files INTEGER,
    cycle_count INTEGER,
    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
    FOREIGN KEY (repo_id) REFERENCES repo(id) ON DELETE CASCADE
);

CREATE TABLE file_snapshot (
    snapshot_id TEXT NOT NULL,
    file_path TEXT NOT NULL,
    dependency_importance REAL,
    connectivity REAL,
    churn REAL,
    risk_score REAL,
    risk_level TEXT CHECK (risk_level IN ('HIGH', 'MEDIUM', 'LOW')),
    impact_count INTEGER DEFAULT 0,
    PRIMARY KEY (snapshot_id, file_path),
    FOREIGN KEY (snapshot_id) REFERENCES snapshot(id) ON DELETE CASCADE
);

CREATE TABLE dependency_edge (
    snapshot_id TEXT NOT NULL,
    from_file TEXT NOT NULL,
    to_file TEXT NOT NULL,
    PRIMARY KEY (snapshot_id, from_file, to_file),
    FOREIGN KEY (snapshot_id) REFERENCES snapshot(id) ON DELETE CASCADE
);

CREATE TABLE cycle (
    id TEXT PRIMARY KEY,
    snapshot_id TEXT NOT NULL,
    nodes TEXT NOT NULL,
    FOREIGN KEY (snapshot_id) REFERENCES snapshot(id) ON DELETE CASCADE
);
```

## Usage Examples

### Initialize with SQLite (default)
```bash
repostem init
# or
repostem init --storage sqlite --db-path .repostem.db
```

### Initialize with PostgreSQL
```bash
repostem init --storage postgresql --db-path postgresql://user:pass@localhost/db
```

### Reconfigure storage
```bash
# When config exists, run init again and select "Reconfigure storage backend"
repostem init --storage postgresql --db-path postgresql://user:pass@localhost/newdb
```

### Reset persistence
```bash
# When config exists, run init again and select "Reset persistence"
repostem init
```

## Implementation Notes

### Repo ID Stability
- `repo_id` is generated as UUID during initial initialization
- When reconfiguring storage, the existing `repo_id` is preserved
- This ensures repository identity remains stable across storage changes
- The repo_id is stored in both the config file and database

### Config File Priority
- Primary: `.repostem.json`
- Fallback: `repostem.config.json`
- Both file names are supported for flexibility

### Adapter Pattern
- Database operations abstracted through adapter interface
- Easy to add new database types in the future
- Consistent API across different storage backends

## Future Enhancements
- Implement snapshot saving in `analyze` command
- Implement drift detection command
- Implement history viewing command
- Implement hotspots tracking with trend analysis
- Implement temporal `ask` queries

## Checklist
- [x] Database adapter implementation
- [x] SQL schema and migrations
- [x] Repository layer
- [x] Engine functions (init, reset, check)
- [x] CLI init command with prompts
- [x] Config file updates
- [x] Type definitions
- [x] Tests
- [x] Documentation updates
- [x] Reconfiguration with repo_id preservation
