### PR TITLE
Refactor analyze-service to use buildSnapshot consistently

### DIFF
--- a/packages/engine/src/application/analyze-service.ts
+++ b/packages/engine/src/application/analyze-service.ts
@@ -14,35 +14,27 @@ import {
 } from "../types";
 
 async function explainFileRisk(repoPath: string, filePath: string, useAI: boolean = true): Promise<string> {
-  const structuredDependenciesData = parseRepository(repoPath);
-  const dependencyGraph = buildDependencyGraph(structuredDependenciesData);
+  const snapshot = await buildSnapshot(repoPath);
   
-  if (!dependencyGraph.getNode(filePath)) {
-    throw new Error(`File ${filePath} not found in metrics`);
+  const fileSnapshot = snapshot.files.get(filePath);
+  if (!fileSnapshot) {
+    throw new Error(`File ${filePath} not found in snapshot`);
   }
   
-  const fileMetrics = await computeFileMetrics(dependencyGraph, filePath);
-  const fileRiskResult = computeFileRisk(filePath, fileMetrics);
   const fileAnalysis = {
     file: filePath,
-    metrics: fileMetrics,
-    riskScore: fileRiskResult.riskScore,
-    riskLevel: fileRiskResult.riskLevel
+    metrics: fileSnapshot.metrics,
+    riskScore: fileSnapshot.riskScore,
+    riskLevel: fileSnapshot.riskLevel
   };
   
   if (useAI) {
     return await explainRiskIntent(fileAnalysis);
   }
-  return `The file ${filePath} has a risk score of ${fileAnalysis.riskScore}. It has a centrality of ${fileMetrics.centrality}, a coupling of ${fileMetrics.coupling}, and a churn of ${fileMetrics.churn}.`;
+  return `The file ${filePath} has a risk score of ${fileAnalysis.riskScore}. It has a centrality of ${fileAnalysis.metrics.centrality}, a coupling of ${fileAnalysis.metrics.coupling}, and a churn of ${fileAnalysis.metrics.churn}.`;
 }
 
 async function explainFileImpact(repoPath: string, filePath: string, useAI: boolean = true): Promise<string> {
-  const structuredDependenciesData = parseRepository(repoPath);
-  const dependencyGraph = buildDependencyGraph(structuredDependenciesData);
-  
-  if (!dependencyGraph.getNode(filePath)) {
-    throw new Error(`File ${filePath} not found in metrics`);
-  }
   
   const fileImpact = await computeFileImpact(repoPath, filePath);
   
@@ -70,24 +62,21 @@ export async function analyzeRepository(repoPath: string): Promise<AnalyzeReposi
  * Analyze risk for a specific file
  */
 export async function analyzeFileRisk(repoPath: string, filePath: string): Promise<FileRiskAnalysisResult> {
-  const structuredDependenciesData = parseRepository(repoPath);
-  const dependencyGraph = buildDependencyGraph(structuredDependenciesData);
+  const snapshot = await buildSnapshot(repoPath);
   
-  if (!dependencyGraph.getNode(filePath)) {
-    throw new Error(`File ${filePath} not found in metrics`);
+  const fileSnapshot = snapshot.files.get(filePath);
+  if (!fileSnapshot) {
+    throw new Error(`File ${filePath} not found in snapshot`);
   }
-  
-  const fileMetrics = await computeFileMetrics(dependencyGraph, filePath);
-  const fileRiskResult = computeFileRisk(filePath, fileMetrics);
   
   return {
     file: filePath,
-    centrality: fileMetrics.centrality || 0,
-    coupling: fileMetrics.coupling || 0,
-    churn: fileMetrics.churn || 0,
-    hasCircularDependency: Boolean(fileMetrics.circularDependency),
-    riskScore: fileRiskResult.riskScore,
-    riskLevel: fileRiskResult.riskLevel
+    centrality: fileSnapshot.metrics.centrality || 0,
+    coupling: fileSnapshot.metrics.coupling || 0,
+    churn: fileSnapshot.metrics.churn || 0,
+    hasCircularDependency: Boolean(fileSnapshot.metrics.circularDependency),
+    riskScore: fileSnapshot.riskScore,
+    riskLevel: fileSnapshot.riskLevel
   };
 }
 
@@ -97,6 +86,9 @@ export async function analyzeFileRisk(repoPath: string, filePath: string): Promi
 export async function computeFileImpact(repoPath: string, filePath: string): Promise<FileImpactResult> {
   const structuredDependenciesData = parseRepository(repoPath);
   const dependencyGraph = buildDependencyGraph(structuredDependenciesData);
+  if (!dependencyGraph.getNode(filePath)) {
+    throw new Error(`File ${filePath} not found in metrics`);
+  }
   return computeImpact(dependencyGraph, filePath);
 }
 
@@ -104,9 +96,8 @@ export async function computeFileImpact(repoPath: string, filePath: string): Pro
  * Detect cycles in the repository
  */
 export async function detectRepositoryCycles(repoPath: string): Promise<Cycle[]> {
-  const structuredDependenciesData = parseRepository(repoPath);
-  const dependencyGraph = buildDependencyGraph(structuredDependenciesData);
-  return dependencyGraph.detectCycles();
+  const snapshot = await buildSnapshot(repoPath);
+  return snapshot.cycles;
 }
 
 export { explainFileRisk, explainFileImpact };

--- a/packages/engine/src/application/ask-service.test.ts
+++ b/packages/engine/src/application/ask-service.test.ts
@@ -53,6 +53,29 @@ vi.mock('../core/impact-engine/impact-engine', () => ({
     }))
 }));
 
+// Mock snapshot builder
+vi.mock('../core/snapshot-builder', () => ({
+    buildSnapshot: vi.fn().mockResolvedValue({
+        metadata: {
+            branch: 'main',
+            commitHash: 'abc123',
+            dirty: false,
+            createdAt: new Date()
+        },
+        summary: {
+            totalFiles: 2,
+            totalDependencies: 1,
+            cycleCount: 0
+        },
+        files: new Map([
+            ['src/index.ts', { path: 'src/index.ts', metrics: { centrality: 0.5, coupling: 0.3, churn: 0.2 }, riskScore: 0.35, riskLevel: 'medium' }],
+            ['src/utils/helper.ts', { path: 'src/utils/helper.ts', metrics: { centrality: 0.8, coupling: 0.4, churn: 0.1 }, riskScore: 0.28, riskLevel: 'low' }]
+        ]),
+        edges: new Map([['src/index.ts', new Set(['src/utils/helper.ts'])]]),
+        cycles: []
+    })
+}));
+
 // Mock AI explanation layer
 vi.mock('../ai-explanation-layer/intent-router', () => ({
     detectIntent: vi.fn((question: string) => {


### PR DESCRIPTION
# Refactor analyze-service to use buildSnapshot consistently

This PR refactors the [analyze-service.ts](cci:7://file:///Users/mohamedmohamed/Desktop/projects/repostem/packages/engine/src/application/analyze-service.ts:0:0-0:0) to consistently use the [buildSnapshot](cci:1://file:///Users/mohamedmohamed/Desktop/projects/repostem/packages/engine/src/core/snapshot-builder.ts:9:0-33:1) function instead of manually parsing repositories and building dependency graphs in each individual function.

## Changes

- **explainFileRisk**: Replaced manual `parseRepository` + `buildDependencyGraph` with [buildSnapshot](cci:1://file:///Users/mohamedmohamed/Desktop/projects/repostem/packages/engine/src/core/snapshot-builder.ts:9:0-33:1), extracts file data from snapshot
- **analyzeFileRisk**: Same refactoring - uses snapshot instead of manual parsing/graph building
- **detectRepositoryCycles**: Uses snapshot and returns `snapshot.cycles` instead of computing from dependency graph

## Benefits

- Reduces code duplication - snapshot building logic is centralized
- Improves efficiency - snapshot is built once per function call instead of re-parsing
- Consistent data source across all analysis functions
- Easier to maintain - single source of truth for repository analysis data